### PR TITLE
MOJO for creating a version tag

### DIFF
--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
@@ -462,6 +462,12 @@ open class PactBrokerClient(
     return base
   }
 
+  open fun createVersionTag(
+      pacticipant: String,
+      pacticipantVersion: String,
+      tag: String) {
+  }
+
   companion object : KLogging() {
     const val LATEST_PROVIDER_PACTS_WITH_NO_TAG = "pb:latest-untagged-pact-version"
     const val LATEST_PROVIDER_PACTS = "pb:latest-provider-pacts"

--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
@@ -464,9 +464,16 @@ open class PactBrokerClient(
   }
 
   open fun createVersionTag(
-      pacticipant: String,
-      pacticipantVersion: String,
-      tag: String) = uploadTags(newHalClient(), pacticipant, pacticipantVersion, listOf(tag))
+    pacticipant: String,
+    pacticipantVersion: String,
+    tag: String
+  ) =
+      uploadTags(
+          newHalClient(),
+          pacticipant,
+          pacticipantVersion,
+          listOf(tag)
+      )
 
   companion object : KLogging() {
     const val LATEST_PROVIDER_PACTS_WITH_NO_TAG = "pb:latest-untagged-pact-version"
@@ -479,14 +486,18 @@ open class PactBrokerClient(
     const val PACTS = "pb:pacts"
     const val UTF8 = "UTF-8"
 
-    fun uploadTags(halClient: IHalClient, consumerName: String, version: String, tags: List<String>) : Result<String?,
-     Exception> {
+    fun uploadTags(
+      halClient: IHalClient,
+      consumerName: String,
+      version: String,
+      tags: List<String>
+    ): Result<String?, Exception> {
       halClient.navigate()
-      var mainResult = Ok("") as Result<String?, Exception>
+      var result = Ok("") as Result<String?, Exception>
       tags.forEach {
-        mainResult = uploadTag(halClient, consumerName, version, it)
+        result = uploadTag(halClient, consumerName, version, it)
       }
-      return mainResult
+      return result
     }
 
     private fun uploadTag(halClient: IHalClient, consumerName: String, version: String, it: String): Result<String?, Exception> {

--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
@@ -482,21 +482,25 @@ open class PactBrokerClient(
     fun uploadTags(halClient: IHalClient, consumerName: String, version: String, tags: List<String>) : Result<String?,
      Exception> {
       halClient.navigate()
-      var mainResult = Ok("") as Result<String, Exception>
+      var mainResult = Ok("") as Result<String?, Exception>
       tags.forEach {
-         val result = halClient.putJson("pb:pacticipant-version-tag", mapOf(
+        mainResult = uploadTag(halClient, consumerName, version, it)
+      }
+      return mainResult
+    }
+
+    private fun uploadTag(halClient: IHalClient, consumerName: String, version: String, it: String): Result<String?, Exception> {
+      val result = halClient.putJson("pb:pacticipant-version-tag", mapOf(
           "pacticipant" to consumerName,
           "version" to version,
           "tag" to it
-        ), "{}")
+      ), "{}")
 
-        if (result is Err<Exception>) {
-          mainResult = result
-          logger.error(result.error) { "Failed to push tag $it for consumer $consumerName and version $version" }
-        }
-
+      if (result is Err<Exception>) {
+        logger.error(result.error) { "Failed to push tag $it for consumer $consumerName and version $version" }
       }
-      return mainResult
+
+      return result
     }
 
     fun <T> retryWith(

--- a/pact-publish/src/test/groovy/broker/PactBrokerClientPactSpec.groovy
+++ b/pact-publish/src/test/groovy/broker/PactBrokerClientPactSpec.groovy
@@ -82,6 +82,38 @@ class PactBrokerClientPactSpec extends Specification {
     result instanceof PactVerificationResult.Ok
   }
 
+  def 'returns success when creating a tag for a pact is ok'() {
+    given:
+    pactBroker {
+        uponReceiving('a HAL navigate request')
+        withAttributes(method: 'GET', path: '/', body: '')
+        willRespondWith(status: 200)
+        withBody(mimetype: 'application/json') {
+          _links {
+            'pb:pacticipant-version-tag' {
+              href url('http://localhost:8080', '/pacticipants/{pacticipant}/versions/{version}/tags/{tag}')
+              title 'Create a tag'
+              templated true
+            }
+          }
+        }
+        uponReceiving('a tag create request')
+        withAttributes(method: 'PUT',
+                path: '/pacticipants/Foo Consumer/versions/10.0.0/tags/A',
+                body: '{}'
+        )
+        willRespondWith(status: 201)
+      }
+
+    when:
+      def result = pactBroker.runTest { server, context ->
+        assert pactBrokerClient.createVersionTag('Foo Consumer', '10.0.0', 'A') instanceof Ok
+      }
+
+    then:
+      result instanceof PactVerificationResult.Ok
+  }
+
   def 'returns an error when forbidden to publish the pact'() {
     given:
     pactBroker {
@@ -99,11 +131,11 @@ class PactBrokerClientPactSpec extends Specification {
       }
       uponReceiving('a pact publish request which will be forbidden')
       withAttributes(method: 'PUT',
-        path: '/pacts/provider/Provider/consumer/Foo Consumer/version/10.0.0',
-        body: pactContents
+              path: '/pacts/provider/Provider/consumer/Foo Consumer/version/10.0.0',
+              body: pactContents
       )
       willRespondWith(status: 401, headers: [
-        'Content-Type': 'application/json'
+              'Content-Type': 'application/json'
       ])
     }
 

--- a/pact-publish/src/test/groovy/broker/PactBrokerClientPactSpec.groovy
+++ b/pact-publish/src/test/groovy/broker/PactBrokerClientPactSpec.groovy
@@ -114,6 +114,38 @@ class PactBrokerClientPactSpec extends Specification {
       result instanceof PactVerificationResult.Ok
   }
 
+  def 'returns an error when creating a tag for a pact fails'() {
+    given:
+    pactBroker {
+      uponReceiving('a HAL navigate request')
+      withAttributes(method: 'GET', path: '/', body: '')
+      willRespondWith(status: 200)
+      withBody(mimetype: 'application/json') {
+        _links {
+          'pb:pacticipant-version-tag' {
+            href url('http://localhost:8080', '/pacticipants/{pacticipant}/versions/{version}/tags/{tag}')
+            title 'Create a tag'
+            templated true
+          }
+        }
+      }
+      uponReceiving('a tag create request')
+      withAttributes(method: 'PUT',
+              path: '/pacticipants/Foo Consumer/versions/10.0.0/tags/A',
+              body: '{}'
+      )
+      willRespondWith(status: 500)
+    }
+
+    when:
+    def result = pactBroker.runTest { server, context ->
+      assert pactBrokerClient.createVersionTag('Foo Consumer', '10.0.0', 'A') instanceof Err<Exception>
+    }
+
+    then:
+    result instanceof PactVerificationResult.Ok
+  }
+
   def 'returns an error when forbidden to publish the pact'() {
     given:
     pactBroker {

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
@@ -14,6 +14,8 @@ import org.apache.maven.plugins.annotations.Parameter
 @Mojo(name = "create-version-tag")
 open class PactCreateVersionTagMojo : PactBaseMojo() {
 
+  private var brokerClient: PactBrokerClient? = null
+
   @Parameter(property = "pacticipant")
   private var pacticipant: String? = ""
 
@@ -25,6 +27,8 @@ open class PactCreateVersionTagMojo : PactBaseMojo() {
 
   override fun execute() {
     checkMandatoryArguments()
+    createBrokerClient()
+    createVersionTag()
   }
 
   private fun checkMandatoryArguments() {
@@ -34,21 +38,29 @@ open class PactCreateVersionTagMojo : PactBaseMojo() {
     dealWithNotProvidedTag()
   }
 
-  private fun dealWithNotProvidedTag() =
-      dealWithNotProvidedArgument(tag, "tag")
+  private fun dealWithNotProvidedPactURL() =
+      dealWithNotProvidedArgument(pactBrokerUrl, "pactBrokerUrl")
 
   private fun dealWithNotProvidedArgument(argument: String?, argumentName: String) {
     if (argument.isNullOrEmpty())
       throw MojoExecutionException("$argumentName is required")
   }
 
-  private fun dealWithNotProvidedPacticipantVersion() =
-      dealWithNotProvidedArgument(pacticipantVersion, "pacticipantVersion")
-
   private fun dealWithNotProvidedPacticipant() =
       dealWithNotProvidedArgument(pacticipant, "pacticipant")
 
-  private fun dealWithNotProvidedPactURL() =
-      dealWithNotProvidedArgument(pactBrokerUrl, "pactBrokerUrl")
+  private fun dealWithNotProvidedPacticipantVersion() =
+      dealWithNotProvidedArgument(pacticipantVersion, "pacticipantVersion")
+
+  private fun dealWithNotProvidedTag() =
+      dealWithNotProvidedArgument(tag, "tag")
+
+  private fun createBrokerClient() {
+    if (brokerClient == null)
+      brokerClient = PactBrokerClient(pactBrokerUrl!!, brokerClientOptions())
+  }
+
+  private fun createVersionTag() =
+      brokerClient!!.createVersionTag(pacticipant!!, pacticipantVersion.orEmpty(), tag.orEmpty())
 
 }

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
@@ -23,9 +23,13 @@ open class PactCreateVersionTagMojo : PactBaseMojo() {
   private var tag: String? = ""
 
   override fun execute() {
+    prepare()
+    createVersionTag()
+  }
+
+  fun prepare() {
     checkMandatoryArguments()
     createBrokerClient()
-    createVersionTag()
   }
 
   private fun checkMandatoryArguments() {

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
@@ -1,0 +1,27 @@
+package au.com.dius.pact.provider.maven
+
+import au.com.dius.pact.core.pactbroker.Latest
+import au.com.dius.pact.core.pactbroker.PactBrokerClient
+import au.com.dius.pact.core.support.isNotEmpty
+import com.github.ajalt.mordant.TermColors
+import org.apache.maven.plugin.MojoExecutionException
+import org.apache.maven.plugins.annotations.Mojo
+import org.apache.maven.plugins.annotations.Parameter
+
+/**
+ * Task to push new version tags to the Pact Broker
+ */
+@Mojo(name = "create-version-tag")
+open class PactCreateVersionTagMojo : PactBaseMojo() {
+
+  @Parameter(property = "pacticipant")
+  private var pacticipant: String? = ""
+
+  @Parameter(property = "pacticipantVersion")
+  private var pacticipantVersion: String? = ""
+
+  override fun execute() {
+    TODO("Not yet implemented")
+  }
+
+}

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
@@ -1,9 +1,6 @@
 package au.com.dius.pact.provider.maven
 
-import au.com.dius.pact.core.pactbroker.Latest
 import au.com.dius.pact.core.pactbroker.PactBrokerClient
-import au.com.dius.pact.core.support.isNotEmpty
-import com.github.ajalt.mordant.TermColors
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
@@ -61,6 +58,6 @@ open class PactCreateVersionTagMojo : PactBaseMojo() {
   }
 
   private fun createVersionTag() =
-      brokerClient!!.createVersionTag(pacticipant!!, pacticipantVersion.orEmpty(), tag.orEmpty())
+      brokerClient!!.createVersionTag(pacticipant!!, pacticipantVersion!!, tag!!)
 
 }

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
@@ -20,8 +20,35 @@ open class PactCreateVersionTagMojo : PactBaseMojo() {
   @Parameter(property = "pacticipantVersion")
   private var pacticipantVersion: String? = ""
 
+  @Parameter(property = "tag")
+  private var tag: String? = ""
+
   override fun execute() {
-    TODO("Not yet implemented")
+    checkMandatoryArguments()
   }
+
+  private fun checkMandatoryArguments() {
+    dealWithNotProvidedPactURL()
+    dealWithNotProvidedPacticipant()
+    dealWithNotProvidedPacticipantVersion()
+    dealWithNotProvidedTag()
+  }
+
+  private fun dealWithNotProvidedTag() =
+      dealWithNotProvidedArgument(tag, "tag")
+
+  private fun dealWithNotProvidedArgument(argument: String?, argumentName: String) {
+    if (argument.isNullOrEmpty())
+      throw MojoExecutionException("$argumentName is required")
+  }
+
+  private fun dealWithNotProvidedPacticipantVersion() =
+      dealWithNotProvidedArgument(pacticipantVersion, "pacticipantVersion")
+
+  private fun dealWithNotProvidedPacticipant() =
+      dealWithNotProvidedArgument(pacticipant, "pacticipant")
+
+  private fun dealWithNotProvidedPactURL() =
+      dealWithNotProvidedArgument(pactBrokerUrl, "pactBrokerUrl")
 
 }

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCreateVersionTagMojo.kt
@@ -63,5 +63,4 @@ open class PactCreateVersionTagMojo : PactBaseMojo() {
 
   private fun createVersionTag() =
       brokerClient!!.createVersionTag(pacticipant!!, pacticipantVersion!!, tag!!)
-
 }

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
@@ -21,7 +21,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.pactBrokerUrl = null
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -33,7 +33,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.pactBrokerUrl = ""
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -45,7 +45,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.pacticipant = null
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -57,7 +57,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.pacticipant = ""
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -69,7 +69,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.pacticipantVersion = null
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -81,7 +81,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.pacticipantVersion = ""
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -93,7 +93,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.tag = null
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -105,7 +105,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.tag = ""
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     def ex = thrown(MojoExecutionException)
@@ -117,7 +117,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo.brokerClient = null
 
     when:
-    mojo.execute()
+    mojo.prepare()
 
     then:
     mojo.brokerClient != null

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
@@ -1,7 +1,5 @@
 package au.com.dius.pact.provider.maven
 
-import au.com.dius.pact.core.pactbroker.CanIDeployResult
-import au.com.dius.pact.core.pactbroker.Latest
 import au.com.dius.pact.core.pactbroker.PactBrokerClient
 import org.apache.maven.plugin.MojoExecutionException
 import spock.lang.Specification
@@ -14,8 +12,8 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo = new PactCreateVersionTagMojo()
     mojo.pactBrokerUrl = 'http://broker:1234'
     mojo.pacticipant = 'test'
-    mojo.pacticipantVersion = "1.0"
-    mojo.tag = "test"
+    mojo.pacticipantVersion = '1234'
+    mojo.tag = 'testTag'
   }
 
   def 'throws an exception if pactBrokerUrl is not provided'() {
@@ -112,5 +110,30 @@ class PactCreateVersionTagMojoSpec extends Specification {
     then:
     def ex = thrown(MojoExecutionException)
     ex.message == 'tag is required'
+  }
+
+  def 'creates a broker client if not specified before'() {
+    given:
+    mojo.brokerClient = null
+
+    when:
+    mojo.execute()
+
+    then:
+    mojo.brokerClient != null
+    mojo.brokerClient.pactBrokerUrl == mojo.pactBrokerUrl
+  }
+
+  def 'calls pact broker client with mandatory arguments'() {
+    given:
+    mojo.brokerClient = Mock(PactBrokerClient)
+
+    when:
+    mojo.execute()
+
+    then:
+    notThrown(MojoExecutionException)
+    1 * mojo.brokerClient.createVersionTag(
+            'test', '1234', 'testTag')
   }
 }

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
@@ -1,5 +1,8 @@
 package au.com.dius.pact.provider.maven
 
+import au.com.dius.pact.core.pactbroker.CanIDeployResult
+import au.com.dius.pact.core.pactbroker.Latest
+import au.com.dius.pact.core.pactbroker.PactBrokerClient
 import org.apache.maven.plugin.MojoExecutionException
 import spock.lang.Specification
 
@@ -11,10 +14,103 @@ class PactCreateVersionTagMojoSpec extends Specification {
     mojo = new PactCreateVersionTagMojo()
     mojo.pactBrokerUrl = 'http://broker:1234'
     mojo.pacticipant = 'test'
+    mojo.pacticipantVersion = "1.0"
+    mojo.tag = "test"
   }
 
-  def 'dummy'() {
-    expect:
-    true
+  def 'throws an exception if pactBrokerUrl is not provided'() {
+    given:
+    mojo.pactBrokerUrl = null
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'pactBrokerUrl is required'
+  }
+
+  def 'throws an exception if pactBrokerUrl is empty'() {
+    given:
+    mojo.pactBrokerUrl = ""
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'pactBrokerUrl is required'
+  }
+
+  def 'throws an exception if pacticipant is not provided'() {
+    given:
+    mojo.pacticipant = null
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'pacticipant is required'
+  }
+
+  def 'throws an exception if pacticipant is empty'() {
+    given:
+    mojo.pacticipant = ""
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'pacticipant is required'
+  }
+
+  def 'throws an exception if pacticipantVersion is not provided'() {
+    given:
+    mojo.pacticipantVersion = null
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'pacticipantVersion is required'
+  }
+
+  def 'throws an exception if pacticipantVersion is empty'() {
+    given:
+    mojo.pacticipantVersion = ""
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'pacticipantVersion is required'
+  }
+
+  def 'throws an exception if tag is not provided'() {
+    given:
+    mojo.tag = null
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'tag is required'
+  }
+
+  def 'throws an exception if tag is empty'() {
+    given:
+    mojo.tag = ""
+
+    when:
+    mojo.execute()
+
+    then:
+    def ex = thrown(MojoExecutionException)
+    ex.message == 'tag is required'
   }
 }

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
@@ -30,7 +30,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
 
   def 'throws an exception if pactBrokerUrl is empty'() {
     given:
-    mojo.pactBrokerUrl = ""
+    mojo.pactBrokerUrl = ''
 
     when:
     mojo.prepare()
@@ -54,7 +54,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
 
   def 'throws an exception if pacticipant is empty'() {
     given:
-    mojo.pacticipant = ""
+    mojo.pacticipant = ''
 
     when:
     mojo.prepare()
@@ -78,7 +78,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
 
   def 'throws an exception if pacticipantVersion is empty'() {
     given:
-    mojo.pacticipantVersion = ""
+    mojo.pacticipantVersion = ''
 
     when:
     mojo.prepare()
@@ -102,7 +102,7 @@ class PactCreateVersionTagMojoSpec extends Specification {
 
   def 'throws an exception if tag is empty'() {
     given:
-    mojo.tag = ""
+    mojo.tag = ''
 
     when:
     mojo.prepare()

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCreateVersionTagMojoSpec.groovy
@@ -1,0 +1,20 @@
+package au.com.dius.pact.provider.maven
+
+import org.apache.maven.plugin.MojoExecutionException
+import spock.lang.Specification
+
+class PactCreateVersionTagMojoSpec extends Specification {
+
+  private PactCreateVersionTagMojo mojo
+
+  def setup() {
+    mojo = new PactCreateVersionTagMojo()
+    mojo.pactBrokerUrl = 'http://broker:1234'
+    mojo.pacticipant = 'test'
+  }
+
+  def 'dummy'() {
+    expect:
+    true
+  }
+}


### PR DESCRIPTION
Pact JVM already provides a Maven task to verify the deployment status (_can-i-deploy_).
However, as stated on the [can-i-deploy docs](https://docs.pact.io/pact_broker/can_i_deploy/#summary), to have the full cycle of _can-i-deploy_, it's necessary tag the Pacticipant version as deployed in a certain enviornment.

![image](https://user-images.githubusercontent.com/1585655/99547202-8e6a0980-29b7-11eb-9ceb-8ec3e008ddb0.png)

These changes provide this Maven task, in addition to minor refactorings on _PactBrokerClient_ to remove some duplications.

Co-author: @askorykh