### PR TITLE
Configurable HttpClientFactory

### DIFF
--- a/provider/junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/HttpTarget.kt
+++ b/provider/junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/HttpTarget.kt
@@ -5,6 +5,7 @@ import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.model.RequestResponseInteraction
 import au.com.dius.pact.provider.HttpClientFactory
 import au.com.dius.pact.provider.IConsumerInfo
+import au.com.dius.pact.provider.IHttpClientFactory
 import au.com.dius.pact.provider.IProviderInfo
 import au.com.dius.pact.provider.IProviderVerifier
 import au.com.dius.pact.provider.ProviderClient
@@ -36,7 +37,8 @@ open class HttpTarget
     val host: String = "127.0.0.1",
     open val port: Int = 8080,
     val path: String = "/",
-    val insecure: Boolean = false
+    val insecure: Boolean = false,
+    val httpClientFactory: () -> IHttpClientFactory = { HttpClientFactory() }
   ) : BaseTarget() {
 
   /**
@@ -67,7 +69,7 @@ open class HttpTarget
     source: PactSource,
     context: Map<String, Any>
   ) {
-    val client = ProviderClient(provider, HttpClientFactory())
+    val client = ProviderClient(provider, this.httpClientFactory.invoke())
     val result = verifier.verifyResponseFromProvider(provider, interaction as RequestResponseInteraction,
       interaction.description, mutableMapOf(), client, context, consumer.pending)
     reportTestResult(result, verifier)

--- a/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/TestTarget.kt
+++ b/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/TestTarget.kt
@@ -8,6 +8,7 @@ import au.com.dius.pact.core.model.RequestResponseInteraction
 import au.com.dius.pact.core.model.messaging.Message
 import au.com.dius.pact.provider.ConsumerInfo
 import au.com.dius.pact.provider.HttpClientFactory
+import au.com.dius.pact.provider.IHttpClientFactory
 import au.com.dius.pact.provider.IProviderVerifier
 import au.com.dius.pact.provider.PactVerification
 import au.com.dius.pact.provider.ProviderClient
@@ -63,7 +64,8 @@ interface TestTarget {
 open class HttpTestTarget @JvmOverloads constructor (
   val host: String = "localhost",
   val port: Int = 8080,
-  val path: String = "/"
+  val path: String = "/",
+  val httpClientFactory: () -> IHttpClientFactory = { HttpClientFactory() }
 ) : TestTarget {
   override fun isHttpTarget() = true
 
@@ -77,7 +79,7 @@ open class HttpTestTarget @JvmOverloads constructor (
   }
 
   override fun prepareRequest(interaction: Interaction, context: Map<String, Any>): Pair<Any, Any>? {
-    val providerClient = ProviderClient(getProviderInfo("provider"), HttpClientFactory())
+    val providerClient = ProviderClient(getProviderInfo("provider"), this.httpClientFactory.invoke())
     if (interaction is RequestResponseInteraction) {
       return providerClient.prepareRequest(interaction.request.generatedRequest(context)) to providerClient
     }
@@ -116,8 +118,9 @@ open class HttpsTestTarget @JvmOverloads constructor (
   host: String = "localhost",
   port: Int = 8443,
   path: String = "",
-  val insecure: Boolean = false
-) : HttpTestTarget(host, port, path) {
+  val insecure: Boolean = false,
+  httpClientFactory: () -> IHttpClientFactory = { HttpClientFactory() }
+) : HttpTestTarget(host, port, path, httpClientFactory) {
 
   override fun getProviderInfo(serviceName: String, pactSource: PactSource?): ProviderInfo {
     val providerInfo = super.getProviderInfo(serviceName, pactSource)


### PR DESCRIPTION
Hey,
the current implementation of HttpTargets made it quite hard to change the Implementation of the httpClient used for the Tests. Currently we use a custom subclass with a lot of copied code, just to change the httpClientFactory, so i thought as the rest of the code is already nicely prepared for extension (interface for the client-factory i.e), why not let the factory be customizable too?

Hope the code is alright, this is my first edit of any kotlin-code ever 🙈 