### PR TITLE
Document groovyClasspath tip to avoid build failures when using Gradle

### DIFF
--- a/consumer/groovy/README.md
+++ b/consumer/groovy/README.md
@@ -21,6 +21,14 @@ If you are using gradle for your build, add it to your `build.gradle`:
     dependencies {
         testCompile 'au.com.dius.pact.consumer:groovy:4.1.0'
     }
+    
+In order to avoid the name collision between `au.com.dius.pact.consumer:groovy` and Groovy Gradle plugin's [automatic configuraiton of `groovyClasspath`](https://docs.gradle.org/current/userguide/groovy_plugin.html#sec:automatic_configuration_of_groovyclasspath)
+add the following configuration to your `build.gradle`:
+```groovy
+compileTestGroovy {
+    groovyClasspath = configurations.testCompileClasspath
+}
+```
 
 Then create an instance of the `PactBuilder` in your test.
 


### PR DESCRIPTION
Additional documentation to help people avoid failing builds when using Groovy Gradle Plugin and Groovy Consumer. When used together with no additional configuration they lead to strange failures like:
```
Execution failed for task ':compileTestGroovy'.
> Could not resolve all files for configuration ':detachedConfiguration1'.
   > Could not find org.codehaus.groovy:groovy:4.1.0.
```

mentioned here:
https://github.com/pact-foundation/pact-jvm/issues/1257