### PR TITLE
fix: missing failures when merging verification results

### DIFF
--- a/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationResult.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationResult.kt
@@ -121,7 +121,9 @@ sealed class VerificationResult {
   ) : VerificationResult() {
     override fun merge(result: VerificationResult) = when (result) {
       is Ok -> this.copy(failures = failures + result.interactionIds
-        .associateWith { emptyList<VerificationFailureType>() })
+        .associateWith {
+          (if (failures.containsKey(it)) failures[it] else emptyList<VerificationFailureType>())!!
+        })
       is Failed -> Failed(when {
         description.isNotEmpty() && result.description.isNotEmpty() && description != result.description ->
           "$description, ${result.description}"

--- a/provider/src/test/groovy/au/com/dius/pact/provider/VerificationResultSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/VerificationResultSpec.groovy
@@ -21,18 +21,22 @@ class VerificationResultSpec extends Specification {
 
     where:
 
-    result1                     | result2                      | result3
-    new VerificationResult.Ok() | new VerificationResult.Ok()  | new VerificationResult.Ok()
-    new VerificationResult.Ok() | failed([error1], '')         | failed([error1], '')
-    failed([error1], '')        | new VerificationResult.Ok()  | failed([error1], '')
-    failed([error1], '')        | failed([error2], '')         | failed([error1, error2], '')
-    failed([error1], 'A')       | failed([error2], '')         | failed([error1, error2], 'A')
-    failed([error1], '')        | failed([error2], 'B')        | failed([error1, error2], 'B')
-    failed([error1], 'A')       | failed([error2], 'B')        | failed([error1, error2], 'A, B')
-    failed([error1], 'A')       | failed([error2], 'A')        | failed([error1, error2], 'A')
-    failed([error1], 'A')       | failed([error2], 'A')        | failed([error1, error2], 'A')
-    failed([error1], '', true)  | failed([error2], 'A', true)  | failed([error1, error2], 'A', true)
-    failed([error1], '', true)  | failed([error2], 'A', false) | failed([error1, error2], 'A', false)
+    result1                        | result2                        | result3
+    new VerificationResult.Ok()    | new VerificationResult.Ok()    | new VerificationResult.Ok()
+    new VerificationResult.Ok()    | failed([error1], '')           | failed([error1], '')
+    failed([error1], '')           | new VerificationResult.Ok()    | failed([error1], '')
+    failed([error1], '')           | failed([error2], '')           | failed([error1, error2], '')
+    failed([error1], 'A')          | failed([error2], '')           | failed([error1, error2], 'A')
+    failed([error1], '')           | failed([error2], 'B')          | failed([error1, error2], 'B')
+    failed([error1], 'A')          | failed([error2], 'B')          | failed([error1, error2], 'A, B')
+    failed([error1], 'A')          | failed([error2], 'A')          | failed([error1, error2], 'A')
+    failed([error1], 'A')          | failed([error2], 'A')          | failed([error1, error2], 'A')
+    failed([error1], '', true)     | failed([error2], 'A', true)    | failed([error1, error2], 'A', true)
+    failed([error1], '', true)     | failed([error2], 'A', false)   | failed([error1, error2], 'A', false)
+    failed(['1': [error1]], '')    | new VerificationResult.Ok('1') | failed(['1': [error1]], '')
+    failed(['1': [error1]], '')    | new VerificationResult.Ok('2') | failed(['1': [error1], '2': []], '')
+    new VerificationResult.Ok('1') | failed(['1': [error1]], '')    | failed(['1': [error1]], '')
+    new VerificationResult.Ok('2') | failed(['1': [error1]], '')    | failed(['1': [error1], '2': []], '')
   }
 
   def 'convert to TestResult - Exception'() {
@@ -118,6 +122,10 @@ class VerificationResultSpec extends Specification {
   }
 
   private static VerificationResult.Failed failed(List errors, String s, pending = false) {
-    new VerificationResult.Failed(s, '', ['': errors], pending)
+    failed(['': errors], s, pending)
+  }
+
+  private static VerificationResult.Failed failed(Map<String, List> interactionIdsToErrors, String s, pending = false) {
+    new VerificationResult.Failed(s, '', interactionIdsToErrors, pending)
   }
 }


### PR DESCRIPTION
When failures and success results had the same interactionId, the failures would be
overwritten by an empty list. This fix sees if there's a failure with the same
interactionId and uses the list of failues to map to the interactionId, otherwise
we just use the empty list.