### PR TITLE
Fix: consumer name in the verification reporting logging

### DIFF
--- a/provider/src/main/kotlin/au/com/dius/pact/provider/reporters/AnsiConsoleReporter.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/reporters/AnsiConsoleReporter.kt
@@ -55,7 +55,7 @@ class AnsiConsoleReporter(
   override fun finaliseReport() { }
 
   override fun reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo, tag: String?) {
-    var out = "\nVerifying a pact between ${t.bold(consumer.name)}"
+    var out = "\nVerifying a pact between ${t.bold(consumer.name.substringAfter("Pact between "))}"
     if (!consumer.name.contains(provider.name)) {
       out += " and ${t.bold(provider.name)}"
     }

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/reporters/SLF4JReporter.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/reporters/SLF4JReporter.kt
@@ -57,7 +57,7 @@ class SLF4JReporter(
   override fun finaliseReport() = Unit
 
   override fun reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo, tag: String?) {
-    var out = "Verifying a pact between ${consumer.name}"
+    var out = "Verifying a pact between ${consumer.name.substringAfter("Pact between ")}"
     if (!consumer.name.contains(provider.name)) {
       out += " and ${provider.name}"
     }

--- a/provider/src/test/groovy/au/com/dius/pact/provider/reporters/SLF4JReporterSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/reporters/SLF4JReporterSpec.groovy
@@ -15,11 +15,11 @@ class SLF4JReporterSpec extends Specification {
     ReporterManager.createReporter('slf4j', '/tmp/' as File) != null
   }
 
-  def 'can log the verification of a consumer from the PactBroker'(){
+  def 'can log the verification of a consumer from the PactBroker'() {
     given:
     def reporter = ReporterManager.createReporter('slf4j', '/tmp/' as File)
-    def consumer = new ConsumerInfo(name: "Pact between Foo Web Client (v1.0.2) and Activity Service")
-    def provider = new ProviderInfo(name: "Activity Service")
+    def consumer = new ConsumerInfo(name: 'Pact between Foo Web Client (v1.0.2) and Activity Service')
+    def provider = new ProviderInfo(name: 'Activity Service')
 
     ListAppender<ILoggingEvent> testAppender = setupTestLogAppender()
 
@@ -28,14 +28,14 @@ class SLF4JReporterSpec extends Specification {
 
     then:
     def loggedEvent = testAppender.list.get(0)
-    loggedEvent.message.contains("Verifying a pact between Foo Web Client (v1.0.2) and Activity Service")
+    loggedEvent.message.contains('Verifying a pact between Foo Web Client (v1.0.2) and Activity Service')
   }
 
-  def 'can log the verification joining the consumer and provider names'(){
+  def 'can log the verification joining the consumer and provider names'() {
     given:
     def reporter = ReporterManager.createReporter('slf4j', '/tmp/' as File)
-    def consumer = new ConsumerInfo(name: "Foo Web Client")
-    def provider = new ProviderInfo(name: "Activity Service")
+    def consumer = new ConsumerInfo(name: 'Foo Web Client')
+    def provider = new ProviderInfo(name: 'Activity Service')
 
     ListAppender<ILoggingEvent> testAppender = setupTestLogAppender()
 
@@ -44,14 +44,14 @@ class SLF4JReporterSpec extends Specification {
 
     then:
     def loggedEvent = testAppender.list.get(0)
-    loggedEvent.message.contains("Verifying a pact between Foo Web Client and Activity Service")
+    loggedEvent.message.contains('Verifying a pact between Foo Web Client and Activity Service')
   }
 
   private static ListAppender<ILoggingEvent> setupTestLogAppender() {
     def testAppender = new ListAppender<ILoggingEvent>()
     testAppender.start()
 
-    def logger = (Logger) LoggerFactory.getLogger(SLF4JReporter.class)
+    def logger = (Logger) LoggerFactory.getLogger(SLF4JReporter)
     logger.addAppender(testAppender)
 
     testAppender

--- a/provider/src/test/groovy/au/com/dius/pact/provider/reporters/SLF4JReporterSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/reporters/SLF4JReporterSpec.groovy
@@ -1,5 +1,11 @@
 package au.com.dius.pact.provider.reporters
 
+import au.com.dius.pact.provider.ConsumerInfo
+import au.com.dius.pact.provider.ProviderInfo
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
 class SLF4JReporterSpec extends Specification {
@@ -7,6 +13,48 @@ class SLF4JReporterSpec extends Specification {
   def 'can create an instance of a reporter'() {
     expect:
     ReporterManager.createReporter('slf4j', '/tmp/' as File) != null
+  }
+
+  def 'can log the verification of a consumer from the PactBroker'(){
+    given:
+    def reporter = ReporterManager.createReporter('slf4j', '/tmp/' as File)
+    def consumer = new ConsumerInfo(name: "Pact between Foo Web Client (v1.0.2) and Activity Service")
+    def provider = new ProviderInfo(name: "Activity Service")
+
+    ListAppender<ILoggingEvent> testAppender = setupTestLogAppender()
+
+    when:
+    reporter.reportVerificationForConsumer(consumer, provider, null)
+
+    then:
+    def loggedEvent = testAppender.list.get(0)
+    loggedEvent.message.contains("Verifying a pact between Foo Web Client (v1.0.2) and Activity Service")
+  }
+
+  def 'can log the verification joining the consumer and provider names'(){
+    given:
+    def reporter = ReporterManager.createReporter('slf4j', '/tmp/' as File)
+    def consumer = new ConsumerInfo(name: "Foo Web Client")
+    def provider = new ProviderInfo(name: "Activity Service")
+
+    ListAppender<ILoggingEvent> testAppender = setupTestLogAppender()
+
+    when:
+    reporter.reportVerificationForConsumer(consumer, provider, null)
+
+    then:
+    def loggedEvent = testAppender.list.get(0)
+    loggedEvent.message.contains("Verifying a pact between Foo Web Client and Activity Service")
+  }
+
+  private static ListAppender<ILoggingEvent> setupTestLogAppender() {
+    def testAppender = new ListAppender<ILoggingEvent>()
+    testAppender.start()
+
+    def logger = (Logger) LoggerFactory.getLogger(SLF4JReporter.class)
+    logger.addAppender(testAppender)
+
+    testAppender
   }
 
 }


### PR DESCRIPTION
When running provider tests the name of the verified consumer is logged with a prefix of `Verifying a pact between`. 

For a consumer definition created based on the Pact Broker results  - with a name like: `Pact between Some Consumer (2.0.0) and Some Provider` - this leads to some redundant text in the log messages:
```
Verifying a pact between Pact between Some Consumer (2.0.0) and Some Provider [PENDING]
```

Notice the duplicated `pact between` and `Pact between`