### PR TITLE
Added Check for JsonValue.Null for matchRegex

### DIFF
--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
@@ -162,7 +162,7 @@ fun <M : Mismatch> matchRegex(
   actual: Any?,
   mismatchFactory: MismatchFactory<M>
 ): List<M> {
-  val matches = safeToString(actual).matches(Regex(regex))
+  val matches = if (actual is JsonValue.Null) false else safeToString(actual).matches(Regex(regex))
   logger.debug { "comparing ${valueOf(actual)} with regexp $regex at $path -> $matches" }
   return if (matches ||
     expected is List<*> && actual is List<*> ||

--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
@@ -162,7 +162,7 @@ fun <M : Mismatch> matchRegex(
   actual: Any?,
   mismatchFactory: MismatchFactory<M>
 ): List<M> {
-  val matches = if (actual is JsonValue.Null) false else safeToString(actual).matches(Regex(regex))
+  val matches = if (actual == null || actual is JsonValue.Null) false else safeToString(actual).matches(Regex(regex))
   logger.debug { "comparing ${valueOf(actual)} with regexp $regex at $path -> $matches" }
   return if (matches ||
     expected is List<*> && actual is List<*> ||

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
@@ -70,11 +70,12 @@ class MatcherExecutorSpec extends Specification {
     MatcherExecutorKt.domatch(new RegexMatcher(regex), path, expected, actual, mismatchFactory).empty == mustBeEmpty
 
     where:
-    expected | actual                               | regex      || mustBeEmpty
-    'Harry'  | 'Happy'                              | 'Ha[a-z]*' || true
-    'Harry'  | null                                 | 'Ha[a-z]*' || false
-    '100'    | 20123                                | '\\d+'     || true
-    '100'    | new JsonValue.Integer('20123'.chars) | '\\d+'     || true
+    expected                  | actual                                | regex        || mustBeEmpty
+    'Harry'                   | 'Happy'                               | 'Ha[a-z]*'   || true
+    'Harry'                   | null                                  | 'Ha[a-z]*'   || false
+    '100'                     | 20123                                 | '\\d+'       || true
+    '100'                     | new JsonValue.Integer('20123'.chars)  | '\\d+'       || true
+    json('"issue1316"')       | JsonValue.Null.INSTANCE               | '[a-x0-9]+'  || false
   }
 
   @Unroll

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
@@ -77,6 +77,7 @@ class MatcherExecutorSpec extends Specification {
     '100'                     | new JsonValue.Integer('20123'.chars)  | '\\d+'       || true
     json('"harry100"')        | json('"20123happy"')                  | '[a-z0-9]+'  || true
     json('"issue1316"')       | JsonValue.Null.INSTANCE               | '[a-z0-9]+'  || false
+    json('"issue1316"')       | null                                  | '[a-z0-9]*'  || false
   }
 
   @Unroll

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
@@ -75,7 +75,8 @@ class MatcherExecutorSpec extends Specification {
     'Harry'                   | null                                  | 'Ha[a-z]*'   || false
     '100'                     | 20123                                 | '\\d+'       || true
     '100'                     | new JsonValue.Integer('20123'.chars)  | '\\d+'       || true
-    json('"issue1316"')       | JsonValue.Null.INSTANCE               | '[a-x0-9]+'  || false
+    json('"harry100"')        | json('"20123happy"')                  | '[a-z0-9]+'  || true
+    json('"issue1316"')       | JsonValue.Null.INSTANCE               | '[a-z0-9]+'  || false
   }
 
   @Unroll


### PR DESCRIPTION
See #1316 - Tests may incorrectly pass when the Provider sends a `null` required JSON field due to the regex matcher.

The reason for this is that `JsonValue.Null` is serialized into the String `"null"`. Then it is matched against the regex, `"null".matches("[a-z0-9]+")`, and will incorrectly result in a successful match. `JsonValue.Null` should never match a regex.