### PR TITLE
feat: Add support for java LocalDate matching method in pact dsl

### DIFF
--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactDslJsonBody.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactDslJsonBody.kt
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.time.DateFormatUtils
 import org.apache.commons.lang3.time.FastDateFormat
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
@@ -562,6 +563,21 @@ open class PactDslJsonBody : DslPart {
     matchers.addRule(matcherKey(name, rootPath), matchDate(format))
     return this
   }
+
+  /**
+   * Attribute that must match the provided date format
+   * @param name attribute date
+   * @param format date format to match
+   * @param example example date to use for generated values
+   */
+  fun localDate(name: String, format: String, example: LocalDate): PactDslJsonBody {
+    val formatter = DateTimeFormatter.ofPattern(format)
+    val body = body as JsonValue.Object
+    body.add(name, JsonValue.StringValue(formatter.format(example).toCharArray()))
+    matchers.addRule(matcherKey(name, rootPath), matchDate(format))
+    return this
+  }
+
   /**
    * Attribute that must be an ISO formatted time
    * @param name attribute name

--- a/consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -3,6 +3,7 @@ package au.com.dius.pact.consumer;
 import au.com.dius.pact.consumer.dsl.DslPart;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Date;
 import java.util.TimeZone;
@@ -10,6 +11,7 @@ import java.util.TimeZone;
 import au.com.dius.pact.consumer.dsl.PactDslJsonRootValue;
 import au.com.dius.pact.core.support.json.JsonParser;
 import au.com.dius.pact.core.support.json.JsonValue;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -266,6 +268,14 @@ public class PactDslJsonBodyTest {
     assertThat(jsonObject.get("dateBerlin").toString(), is(equalTo("1970-01-01")));
     assertThat(jsonObject.get("timeLosAngeles").toString(), is(equalTo("16:00:00")));
     assertThat(jsonObject.get("timeBerlin").toString(), is(equalTo("01:00:00")));
+  }
+
+  @Test
+  public void testExampleLocalDate() throws Exception {
+    final PactDslJsonBody response = new PactDslJsonBody();
+    response.localDate("localDateExample", "yyyy-MM-dd", LocalDate.EPOCH);
+    JsonValue.Object jsonObject = response.getBody().asObject();
+    assertThat(jsonObject.get("localDateExample").toString(), is(equalTo("1970-01-01")));
   }
 
   @Test


### PR DESCRIPTION
Hi Pact team,
I have added support for java LocalDate matching method in `PactDslJsonBody`.

**The problem**
I have a `LocalDate` object I want to add to `PactDslJsonBody` and I have to convert it to `Date` in order to use it in the `date` matching method:
```
LocalDate exampleLocalDate = LocalDate.now();
Date exampleDate = Date.from(exampleLocalDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
pactDslJsonBody.date("myLocalDateField", "MMM dd, yyyy", exampleDate);
```

**The solution**
I would like to avoid the conversion step and use `LocalDate` directly, for instance by using the matching method I have implemented in this PR:
```
LocalDate exampleLocalDate = LocalDate.now();
pactDslJsonBody.localDate("myLocalDateField", "MMM dd, yyyy", exampleLocalDate);
```

If you find this could be useful for broader audience, it would be great to have it in the next `pact-jvm` release. Thanks for any feedback.
