### PR TITLE
Fix: Allow verifying v4-interactions with junit5

### DIFF
--- a/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactVerificationContext.kt
+++ b/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactVerificationContext.kt
@@ -3,6 +3,7 @@ package au.com.dius.pact.provider.junit5
 import au.com.dius.pact.core.model.Interaction
 import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.model.RequestResponseInteraction
+import au.com.dius.pact.core.model.V4Interaction
 import au.com.dius.pact.core.model.UnknownPactSource
 import au.com.dius.pact.core.model.generators.GeneratorTestMode
 import au.com.dius.pact.core.support.expressions.SystemPropertyResolver
@@ -77,7 +78,11 @@ data class PactVerificationContext @JvmOverloads constructor(
       val interactionMessage = "Verifying a pact between ${consumer.name} and ${providerInfo.name}" +
         " - ${interaction.description}"
       return try {
-        val reqResInteraction = interaction as RequestResponseInteraction
+        val reqResInteraction = if (interaction is V4Interaction.SynchronousHttp) {
+          interaction.asV3Interaction()
+        } else {
+          interaction as RequestResponseInteraction
+        }
         val expectedResponse = reqResInteraction.response.generatedResponse(context, GeneratorTestMode.Provider)
         val actualResponse = target.executeInteraction(client, request)
 


### PR DESCRIPTION
This is a quick and dirty solution for #1368

I don't know if there is a plan on how to handle the v3 vs. v4 models in the provider tests, so please feel free to close this if there's already something in progress. Or point me in the right direction :-) 