### PR TITLE
fix: retain previous summary state when updating markdown report #1128

### DIFF
--- a/provider/src/main/kotlin/au/com/dius/pact/provider/reporters/MarkdownReporter.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/reporters/MarkdownReporter.kt
@@ -232,7 +232,7 @@ class MarkdownReporter(
           }
           if (consumerRow != null) {
             val stateCell = consumerRow.lastChild as TableCell
-            stateCell.text = BasedSequence.of(state)
+            stateCell.text = BasedSequence.of(mergeSummaryStatus(stateCell.text, state))
           } else {
             val row = TableRow()
             val pending = if (consumer.pending) " [Pending]" else ""
@@ -247,6 +247,14 @@ class MarkdownReporter(
           }
         }
       }
+    }
+  }
+
+  private fun mergeSummaryStatus(old: CharSequence, new: CharSequence): CharSequence {
+    return when {
+        old == new -> old
+        old.contains("OK") -> new
+        else -> "Failed"
     }
   }
 

--- a/provider/src/test/groovy/au/com/dius/pact/provider/reporters/MarkdownReporterSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/reporters/MarkdownReporterSpec.groovy
@@ -261,11 +261,11 @@ class MarkdownReporterSpec extends Specification {
     reporter.initialise(provider1)
     reporter.reportVerificationForConsumer(consumer2, provider1, 'master')
     reporter.interactionDescription(interaction2)
+    reporter.statusComparisonFailed(200, 'expected status of 201 but was 200')
     reporter.finaliseReport()
     reporter.initialise(provider1)
     reporter.reportVerificationForConsumer(consumer2, provider1, 'master')
     reporter.interactionDescription(interaction2)
-    reporter.statusComparisonFailed(200, 'expected status of 201 but was 200')
     reporter.finaliseReport()
 
     def results = new File(reportDir, 'provider1.md').text
@@ -276,6 +276,49 @@ class MarkdownReporterSpec extends Specification {
          ||-----------|--------|
          || Consumer  | OK     |
          || Consumer2 | Failed |'''.stripMargin()
+    )
+  }
+
+  @Issue('#1128')
+  def 'updates the summary with multiple failures'() {
+    given:
+    def reporter = new MarkdownReporter('test', reportDir)
+    def provider1 = new ProviderInfo(name: 'provider1')
+    def consumer = new ConsumerInfo(name: 'Consumer')
+    def consumer2 = new ConsumerInfo(name: 'Consumer2')
+    def interaction1 = new RequestResponseInteraction('Interaction 1', [], new Request(), new Response())
+    def interaction2 = new RequestResponseInteraction('Interaction 2', [], new Request(), new Response())
+
+    when:
+    reporter.initialise(provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, 'master')
+    reporter.interactionDescription(interaction1)
+    reporter.requestFailed(provider1, interaction2, 'Failure 1', new Exception(), false)
+    reporter.finaliseReport()
+    reporter.initialise(provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, 'master')
+    reporter.interactionDescription(interaction1)
+    reporter.requestFailed(provider1, interaction2, 'Failure 2', new Exception(), false)
+    reporter.finaliseReport()
+    reporter.initialise(provider1)
+    reporter.reportVerificationForConsumer(consumer2, provider1, 'master')
+    reporter.interactionDescription(interaction2)
+    reporter.statusComparisonFailed(200, 'expected status of 201 but was 200')
+    reporter.finaliseReport()
+    reporter.initialise(provider1)
+    reporter.reportVerificationForConsumer(consumer2, provider1, 'master')
+    reporter.interactionDescription(interaction2)
+    reporter.requestFailed(provider1, interaction2, 'Failure', new Exception(), false)
+    reporter.finaliseReport()
+
+    def results = new File(reportDir, 'provider1.md').text
+
+    then:
+    results.contains(
+      '''|| Consumer  |     Result     |
+         ||-----------|----------------|
+         || Consumer  | Request failed |
+         || Consumer2 | Failed         |'''.stripMargin()
     )
   }
 }


### PR DESCRIPTION
Bug fix for the issue mentioned in #1128 

When the Markdown reporter updates an existing file, it previously would overwrite the summary status with that of the latest interaction. This meant that any intermediary failures would be incorrectly hidden in the summary if a later interaction succeeds.

This fix ensures that failures are not overwritten. Multiple failures of different types would be reported as `Failed`.