### PR TITLE
Correcting definition for arrayMinLike and arrayMaxLike

### DIFF
--- a/consumer/README.md
+++ b/consumer/README.md
@@ -241,8 +241,8 @@ If the root of the body is an array, you can create PactDslJsonArray classes wit
 | function | description |
 |----------|-------------|
 | `arrayEachLike` | Ensure that each item in the list matches the provided example |
-| `arrayMinLike` | Ensure that each item in the list matches the provided example and the list is no bigger than the provided max |
-| `arrayMaxLike` | Ensure that each item in the list matches the provided example and the list is no smaller than the provided min |
+| `arrayMaxLike` | Ensure that each item in the list matches the provided example and the list is no bigger than the provided max |
+| `arrayMinLike` | Ensure that each item in the list matches the provided example and the list is no smaller than the provided min |
 
 For example:
 


### PR DESCRIPTION
The current definition in the documentation: [Root level arrays that match all items](https://docs.pact.io/implementation_guides/jvm/consumer/#root-level-arrays-that-match-all-items)

> | `arrayMinLike` | Ensure that each item in the list matches the provided example and the list is no **bigger** than the provided max |
| `arrayMaxLike` | Ensure that each item in the list matches the provided example and the list is no **smaller** than the provided min |

This should be reversed.