### PR TITLE
feat: add and refactor handling for 404 responses in Maven plugin

### DIFF
--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -302,7 +302,7 @@ class PactProviderMojoSpec extends Specification {
 
     then:
     1 * provider.hasPactsFromPactBrokerWithSelectors([:], 'http://broker:1234', []) >> {
-      throw new NotFoundHalResponse()
+      throw new RuntimeException(new NotFoundHalResponse())
     }
     thrown(NotFoundHalResponse)
     list.size() == 0
@@ -320,7 +320,7 @@ class PactProviderMojoSpec extends Specification {
 
     then:
     1 * provider.hasPactsFromPactBrokerWithSelectors([:], 'http://broker:1234', []) >> {
-      throw new NotFoundHalResponse()
+      throw new RuntimeException(new NotFoundHalResponse())
     }
     noExceptionThrown()
     list.size() == 0


### PR DESCRIPTION
Fixes #1419 now for real.
I've managed to also try this feature out for our case.

With my previous fix (#1421) there were two issues:
* There were other conditional branches, that also requested pacts from the broker (either when `enablePending` was active or `tags` were present)
  * I've refactored the logic, so that the request only is there once
* The expected exception `NotFoundHalResponse` was not thrown, but instead a `RuntimeException` with the `NotFoundHalResponse` as a cause (see Stacktrace#1)

#### Stacktrace#1

```bash
[ERROR] Failed to execute goal au.com.dius.pact.provider:maven:4.2.12:verify (default-cli) on project fulfillment-order-planning-service: Execution default-cli of goal au.com.dius.pact.provider:maven:4.2.12:verify failed: Call to fetch pacts from Pact Broker failed with an exception: No HAL document found at path 'http://localhost:9292/pacts/provider/FOP-Event-PlannedPackageReleased-Provider/for-verification' -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal au.com.dius.pact.provider:maven:4.2.12:verify (default-cli) on project fulfillment-order-planning-service: Execution default-cli of goal au.com.dius.pact.provider:maven:4.2.12:verify failed: Call to fetch pacts from Pact Broker failed with an exception
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal au.com.dius.pact.provider:maven:4.2.12:verify failed: Call to fetch pacts from Pact Broker failed with an exception
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.RuntimeException: Call to fetch pacts from Pact Broker failed with an exception
    at au.com.dius.pact.provider.ProviderInfo.hasPactsFromPactBrokerWithSelectors (ProviderInfo.kt:104)
    at au.com.dius.pact.provider.ProviderInfo.hasPactsFromPactBrokerWithSelectors (ProviderInfo.kt:79)
    at au.com.dius.pact.provider.maven.PactProviderMojo$loadPactsFromPactBroker$3.invoke (PactProviderMojo.kt:215)
    at au.com.dius.pact.core.support.KotlinLanguageSupportKt.handleWith (KotlinLanguageSupport.kt:38)
    at au.com.dius.pact.provider.maven.PactProviderMojo.loadPactsFromPactBroker (PactProviderMojo.kt:214)
    at au.com.dius.pact.provider.maven.PactProviderMojo.execute (PactProviderMojo.kt:133)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: au.com.dius.pact.core.pactbroker.NotFoundHalResponse: No HAL document found at path 'http://localhost:9292/pacts/provider/FOP-Event-PlannedPackageReleased-Provider/for-verification'
    at au.com.dius.pact.core.pactbroker.HalClient.handleHalResponse (HalClient.kt:307)
    at au.com.dius.pact.core.pactbroker.HalClient.access$handleHalResponse (HalClient.kt:142)
    at au.com.dius.pact.core.pactbroker.HalClient$postJson$3.invoke (HalClient.kt:482)
    at au.com.dius.pact.core.support.KotlinLanguageSupportKt.handleWith (KotlinLanguageSupport.kt:38)
    at au.com.dius.pact.core.pactbroker.HalClient.postJson (HalClient.kt:480)
    at au.com.dius.pact.core.pactbroker.PactBrokerClient$fetchPactsUsingNewEndpoint$2.invoke (PactBrokerClient.kt:285)
    at au.com.dius.pact.core.support.KotlinLanguageSupportKt.handleWith (KotlinLanguageSupport.kt:38)
    at au.com.dius.pact.core.pactbroker.PactBrokerClient.fetchPactsUsingNewEndpoint (PactBrokerClient.kt:284)
    at au.com.dius.pact.core.pactbroker.PactBrokerClient.fetchConsumersWithSelectors (PactBrokerClient.kt:243)
    at au.com.dius.pact.provider.ProviderInfo.hasPactsFromPactBrokerWithSelectors (ProviderInfo.kt:94)
    at au.com.dius.pact.provider.ProviderInfo.hasPactsFromPactBrokerWithSelectors (ProviderInfo.kt:79)
    at au.com.dius.pact.provider.maven.PactProviderMojo$loadPactsFromPactBroker$3.invoke (PactProviderMojo.kt:215)
    at au.com.dius.pact.core.support.KotlinLanguageSupportKt.handleWith (KotlinLanguageSupport.kt:38)
    at au.com.dius.pact.provider.maven.PactProviderMojo.loadPactsFromPactBroker (PactProviderMojo.kt:214)
    at au.com.dius.pact.provider.maven.PactProviderMojo.execute (PactProviderMojo.kt:133)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:64)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[ERROR]
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
```
