### PR TITLE
feat: add support of multiple parts in multipart request

### DIFF
--- a/consumer/junit/src/test/groovy/au/com/dius/pact/consumer/junit/ExampleMultipartSpec.groovy
+++ b/consumer/junit/src/test/groovy/au/com/dius/pact/consumer/junit/ExampleMultipartSpec.groovy
@@ -1,0 +1,60 @@
+package au.com.dius.pact.consumer.junit
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import org.apache.http.client.methods.RequestBuilder
+import org.apache.http.entity.ContentType
+import org.apache.http.entity.mime.HttpMultipartMode
+import org.apache.http.entity.mime.MultipartEntityBuilder
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClients
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * It is just an example how to build multipart request with multiple parts
+ * Actual bodies of multipart requests are not compared
+ */
+class ExampleMultipartSpec {
+
+  @Rule
+  @SuppressWarnings('PublicInstanceField')
+  public final PactProviderRule mockProvider = new PactProviderRule('File Service', this)
+
+  @Pact(provider = 'File Service', consumer= 'Junit Consumer')
+  RequestResponsePact createPact(PactDslWithProvider builder) {
+    def multipartEntityBuilder = MultipartEntityBuilder.create()
+      .setMode(HttpMultipartMode.BROWSER_COMPATIBLE)
+      .addBinaryBody('file', '1,2,3,4\n5,6,7,8'.bytes, ContentType.create('text/csv'), 'data.csv')
+      .addTextBody('textPart', 'sample text')
+    builder
+      .uponReceiving('a multipart file POST')
+      .path('/upload')
+      .method('POST')
+      .body(multipartEntityBuilder)
+      .willRespondWith()
+      .status(201)
+      .body('file uploaded ok', 'text/plain')
+      .toPact()
+  }
+
+  @Test
+  @PactVerification
+  void runTest() {
+    CloseableHttpClient httpclient = HttpClients.createDefault()
+    httpclient.withCloseable {
+      def data = MultipartEntityBuilder.create()
+        .setMode(HttpMultipartMode.BROWSER_COMPATIBLE)
+        .addBinaryBody('file', '1,2,3,4\n5,6,7,8'.bytes, ContentType.create('text/csv'), 'data.csv')
+        .addTextBody('textPart', 'sample text')
+        .build()
+      def request = RequestBuilder
+        .post(mockProvider.url + '/upload')
+        .setEntity(data)
+        .build()
+      println('Executing request ' + request.requestLine)
+      httpclient.execute(request)
+    }
+  }
+}

--- a/consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestBase.java
+++ b/consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestBase.java
@@ -58,10 +58,16 @@ public abstract class PactDslRequestBase {
     if (!fileContentType.isEmpty()) {
       contentType = ContentType.create(fileContentType);
     }
-    HttpEntity multipart = MultipartEntityBuilder.create()
+    MultipartEntityBuilder multipart = MultipartEntityBuilder.create()
       .setMode(HttpMultipartMode.BROWSER_COMPATIBLE)
-      .addBinaryBody(partName, data, contentType, fileName)
-      .build();
+      .addBinaryBody(partName, data, contentType, fileName);
+
+    setupMultipart(multipart);
+  }
+
+  protected void setupMultipart(MultipartEntityBuilder multipartBuilder) throws IOException {
+
+    HttpEntity multipart = multipartBuilder.build();
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     multipart.writeTo(os);
 

--- a/consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -16,6 +16,7 @@ import au.com.dius.pact.core.support.expressions.DataType;
 import com.mifmif.common.regex.Generex;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.json.JSONObject;
 import org.w3c.dom.Document;
 
@@ -360,6 +361,16 @@ public class PactDslRequestWithPath extends PactDslRequestBase {
 
     return this;
   }
+
+    /**
+     * The body of the request
+     *
+     * @param body Built using MultipartEntityBuilder
+     */
+    public PactDslRequestWithPath body(MultipartEntityBuilder body) throws IOException {
+        setupMultipart(body);
+        return this;
+    }
 
     /**
      * The path of the request

--- a/consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
+++ b/consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
@@ -11,6 +11,7 @@ import au.com.dius.pact.core.support.expressions.DataType;
 import com.mifmif.common.regex.Generex;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.json.JSONObject;
 import org.w3c.dom.Document;
 
@@ -285,6 +286,16 @@ public class PactDslRequestWithoutPath extends PactDslRequestBase {
         new au.com.dius.pact.core.model.ContentType(contentType));
     }
 
+    return this;
+  }
+
+  /**
+   * The body of the request
+   *
+   * @param body Built using MultipartEntityBuilder
+   */
+  public PactDslRequestWithoutPath body(MultipartEntityBuilder body) throws IOException {
+    setupMultipart(body);
     return this;
   }
 


### PR DESCRIPTION
Hello

We require to build multipart request containing more than a single file part. I know we could build the body and headers on our own, but this approach is a bit cumbersome and there is the need to provide some kind of a builder for such.

I noticed that you are using `org.apache.http.entity.mime.MultipartEntityBuilder` to create the body inside the `au.com.dius.pact.consumer.dsl.PactDslRequestBase#setupFileUpload` method.

I understand that API should be based on the basic types but I saw that there is already `au.com.dius.pact.consumer.dsl.PactDslRequestWithPath#body(java.lang.String, org.apache.http.entity.ContentType)` method  accepting `org.apache.http.entity.ContentType`. Taking that into account I suggest extending the API to accept the `org.apache.http.entity.mime.MultipartEntityBuilder` and utilize it in the similar manner as before.