### PR TITLE
feat: add support for non-file parts in the multipart requests

### DIFF
--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
@@ -98,7 +98,7 @@ class MockMvcTestTarget @JvmOverloads constructor(
           val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
           val filename = contentDisposition.getParameter("filename").orEmpty()
           if (filename.isEmpty()) {
-            multipartRequest.param(name, FileCopyUtils.copyToString(bodyPart.inputStream.bufferedReader()))
+            multipartRequest.part(MockPart(name, FileCopyUtils.copyToByteArray(bodyPart.inputStream)))
           } else {
             multipartRequest.file(MockMultipartFile(name, filename, bodyPart.contentType, bodyPart.inputStream))
           }

--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+import org.springframework.util.FileCopyUtils
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 import javax.mail.internet.ContentDisposition
@@ -96,7 +97,11 @@ class MockMvcTestTarget @JvmOverloads constructor(
           val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
           val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
           val filename = contentDisposition.getParameter("filename").orEmpty()
-          multipartRequest.file(MockMultipartFile(name, filename, bodyPart.contentType, bodyPart.inputStream))
+          if (filename.isEmpty()) {
+            multipartRequest.param(name, FileCopyUtils.copyToString(bodyPart.inputStream.bufferedReader()))
+          } else {
+            multipartRequest.file(MockMultipartFile(name, filename, bodyPart.contentType, bodyPart.inputStream))
+          }
           i++
         }
         multipartRequest.headers(mapHeaders(request, true))


### PR DESCRIPTION
Hello

While working on multipart I couldn't call my API accepting text and file parameters. After some debugging I noticed that during request creation at the provider the parts are always treated as a files. Further investigation lead me to the conclusion that the non-file parts should be treated as the parameters (`org.apache.commons.fileupload.FileUploadBase#parseRequest(org.apache.commons.fileupload.RequestContext` + `org.apache.commons.fileupload.FileUploadBase.FileItemIteratorImpl#findNextItem` + `org.springframework.web.multipart.commons.CommonsFileUploadSupport#parseFileItems` )