### PR TITLE
feat: add support for @TestTarget annotation for junit tests written in scala

### DIFF
--- a/provider/junit/build.gradle
+++ b/provider/junit/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'scala'
+}
+
 dependencies {
     api project(path: ":core:support", configuration: 'default'),
       project(path: ":provider", configuration: 'default')
@@ -9,6 +13,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:${project.slf4jVersion}"
     compile 'com.github.rholder:guava-retrying:2.0.0'
     compile 'javax.mail:mail:1.5.0-b01'
+    compile project(path: ":provider:scalasupport_2.13", configuration: 'default')
 
     testCompile 'com.github.rest-driver:rest-client-driver:1.1.45'
     testCompile 'com.github.tomakehurst:wiremock-jre8:2.27.2'

--- a/provider/junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
+++ b/provider/junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
@@ -48,6 +48,7 @@ import org.junit.runners.model.TestClass
 import java.lang.RuntimeException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Supplier
+import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.kotlinProperty
 import org.apache.commons.lang3.tuple.Pair as TuplePair
 
@@ -271,8 +272,10 @@ open class InteractionRunner(
   protected fun lookupTarget(testInstance: Any, interaction: Interaction): Target {
     val target = testClass.getAnnotatedFields(TestTarget::class.java).map {
       if (it.field.kotlinProperty != null) {
+        it.field.kotlinProperty!!.getter.isAccessible = true
         it.field.kotlinProperty!!.getter.call(testInstance)
       } else {
+        it.field.isAccessible = true
         it.get(testInstance)
       }
     }.first { (it as Target).validForInteraction(interaction) }

--- a/provider/junit/src/test/scala/au/com/dius/pact/provider/junit/ScalaJunitTest.scala
+++ b/provider/junit/src/test/scala/au/com/dius/pact/provider/junit/ScalaJunitTest.scala
@@ -1,0 +1,20 @@
+package au.com.dius.pact.provider.junit
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit.target.MessageTarget
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import au.com.dius.pact.provider.junitsupport.target.TestTarget
+import au.com.dius.pact.provider.junitsupport.{Provider, State}
+import org.junit.runner.RunWith
+
+@RunWith(classOf[PactRunner])
+@Provider("AmqpProvider")
+@PactFolder("src/test/resources/amqp_pacts")
+class ScalaJunitTest {
+  @TestTarget final val target = new MessageTarget
+
+  @State(Array("SomeProviderState")) def someProviderState(): Unit = {
+  }
+
+  @PactVerifyProvider("a test message") def verifyMessageForOrder = "{\"testParam1\": \"value1\",\"testParam2\": \"value2\"}"
+}


### PR DESCRIPTION
When junit test is written in scala `@TestTarget` annotation attached to `val` doesn't work because of:

```
java.lang.IllegalAccessException: class kotlin.reflect.jvm.internal.calls.CallerImpl$FieldGetter cannot access a member of class au.com.dius.pact.provider.junit.ScalaJunitTest with modifiers "private final"
```

In scala if you define class member by `val x` it will be represented in bytecode by private field `x` and public getter method `x()`. Because of this implementation detail it is not possible to use `@TestTarget` annotation on scala's `val x = ...` class member.