### PR TITLE
feat: Add support for configuring consumer version selectors from cli as

### DIFF
--- a/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/PactBrokerClientSpec.groovy
+++ b/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/PactBrokerClientSpec.groovy
@@ -649,6 +649,26 @@ class PactBrokerClientSpec extends Specification {
     result == new Err(["Publishing tag '1' failed: failed"])
   }
 
+  def 'fetches provider pacts for verification based on selectors raw json configuration passed from cli'() {
+    given:
+    System.setProperty('pactbroker.consumerversionselectors.rawjson', '[{"mainBranch":true}]')
+    def halClient = Mock(IHalClient)
+    halClient.navigate() >> halClient
+    halClient.linkUrl("pb:provider-pacts-for-verification") >> "pb:provider-pacts-for-verification"
+    PactBrokerClient client = Spy(PactBrokerClient, constructorArgs: ['baseUrl']) {
+      newHalClient() >> halClient
+    }
+
+    def expectedJson = "{\"consumerVersionSelectors\":[{\"mainBranch\":true}],\"includePendingStatus\":false}"
+
+    when:
+    def consumers = client.fetchConsumersWithSelectors('provider',
+            [], [], false, '')
+
+    then:
+    1 * halClient.postJson("pb:provider-pacts-for-verification", _, expectedJson)
+  }
+
   @Unroll
   @SuppressWarnings('UnnecessaryBooleanExpression')
   def 'can-i-deploy - matrix query'() {


### PR DESCRIPTION
raw json

Based on discussion in #1465, I have implemented a solution that bypasses the actual typed selectors implementation by passing raw_json/untyped selectors configuration directly from system property to the pact broker. This can be used as a workaround for not yet implemented new broker api in typed code.

I tested it on the latest pact broker:
Publish pacts
`pact-broker publish --consumer-app-version 1 --broker-base-url http://localhost:9292 ./pacts --branch master`
Run verification tests and publish results
`mvn clean test -Dpactbroker.url=http://localhost:9292 -Dpactbroker.consumerversionselectors.rawjson=[{\"mainBranch\":true}] -Dpact.provider.version=1 -Dpact.provider.tag=master -Dpact.verifier.publishResults=true -Dpactbroker.enablePending=true -Dpactbroker.providerTags=master`

Results were published using tag `master`, however, due to the automatic migration property, the branch `master` was also created in broker.

See screenshot of the matrix:
![selectors_with_branches_test](https://user-images.githubusercontent.com/2538092/138854700-0f69213f-102f-4d74-b74c-13bd51e043dc.png)
