### PR TITLE
feat: Add support for TestClient as a test target.

### DIFF
--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/WebFluxBasedTestTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/WebFluxBasedTestTarget.kt
@@ -1,0 +1,116 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.core.model.ContentType
+import au.com.dius.pact.core.model.IRequest
+import au.com.dius.pact.core.model.PactSource
+import au.com.dius.pact.provider.IProviderVerifier
+import au.com.dius.pact.provider.ProviderInfo
+import au.com.dius.pact.provider.ProviderResponse
+import au.com.dius.pact.provider.junit5.TestTarget
+import org.apache.commons.lang3.StringUtils
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.http.client.MultipartBodyBuilder
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.util.UriComponentsBuilder
+import javax.mail.internet.ContentDisposition
+import javax.mail.internet.MimeMultipart
+import javax.mail.util.ByteArrayDataSource
+
+/**
+ * An interface for a WebFlux based test target.
+ */
+interface WebFluxBasedTestTarget : TestTarget {
+  override fun getProviderInfo(serviceName: String, pactSource: PactSource?) = ProviderInfo(serviceName)
+
+  override fun isHttpTarget() = true
+
+  override fun executeInteraction(client: Any?, request: Any?): ProviderResponse {
+    val requestBuilder = request as WebTestClient.RequestHeadersSpec<*>
+    val exchangeResult = requestBuilder.exchange().expectBody().returnResult()
+
+    val headers = mutableMapOf<String, List<String>>()
+    exchangeResult.responseHeaders.forEach { header ->
+      headers[header.key] = header.value
+    }
+
+    val contentTypeHeader = exchangeResult.responseHeaders.contentType
+    val contentType = if (contentTypeHeader == null) {
+      ContentType.JSON
+    } else {
+      ContentType.fromString(contentTypeHeader.toString())
+    }
+
+    return ProviderResponse(
+      exchangeResult.status.value(),
+      headers,
+      contentType,
+      exchangeResult.responseBody?.let { String(it) }
+    )
+  }
+
+  override fun prepareVerifier(verifier: IProviderVerifier, testInstance: Any) {
+    /* NO-OP */
+  }
+
+  fun toWebFluxRequestBuilder(webClient: WebTestClient, request: IRequest): WebTestClient.RequestHeadersSpec<*> {
+    return if (request.body.isPresent()) {
+      if (request.isMultipartFileUpload()) {
+        val multipart = MimeMultipart(ByteArrayDataSource(request.body.unwrap(), request.contentTypeHeader()))
+
+        val bodyBuilder = MultipartBodyBuilder()
+        var i = 0
+        while (i < multipart.count) {
+          val bodyPart = multipart.getBodyPart(i)
+          val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
+          val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
+          val filename = contentDisposition.getParameter("filename").orEmpty()
+
+          bodyBuilder
+            .part(name, bodyPart.content)
+            .filename(filename)
+            .contentType(MediaType.valueOf(bodyPart.contentType))
+            .header("Content-Disposition", "form-data; name=$name; filename=$filename")
+
+          i++
+        }
+
+        webClient
+          .method(HttpMethod.POST)
+          .uri(requestUriString(request))
+          .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
+          .headers { request.headers.forEach { (k, v) -> it.addAll(k, v) } }
+      } else {
+        webClient
+          .method(HttpMethod.valueOf(request.method))
+          .uri(requestUriString(request))
+          .bodyValue(request.body.value!!)
+          .headers {
+            request.headers.forEach { (k, v) -> it.addAll(k, v) }
+            if (!request.headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
+              it.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            }
+          }
+      }
+    } else {
+      webClient
+        .method(HttpMethod.valueOf(request.method))
+        .uri(requestUriString(request))
+        .headers {
+          request.headers.forEach { (k, v) -> it.addAll(k, v) }
+        }
+    }
+  }
+
+  fun requestUriString(request: IRequest): String {
+    val uriBuilder = UriComponentsBuilder.fromPath(request.path)
+
+    request.query.forEach { (key, value) ->
+      uriBuilder.queryParam(key, value)
+    }
+
+    return uriBuilder.toUriString()
+  }
+}

--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/WebFluxTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/WebFluxTarget.kt
@@ -1,126 +1,18 @@
 package au.com.dius.pact.provider.spring.junit5
 
-import au.com.dius.pact.core.model.ContentType
-import au.com.dius.pact.core.model.IRequest
 import au.com.dius.pact.core.model.Interaction
-import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.model.SynchronousRequestResponse
 import au.com.dius.pact.core.model.generators.GeneratorTestMode
-import au.com.dius.pact.provider.IProviderVerifier
-import au.com.dius.pact.provider.ProviderInfo
-import au.com.dius.pact.provider.ProviderResponse
-import au.com.dius.pact.provider.junit5.TestTarget
-import org.apache.commons.lang3.StringUtils
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpMethod
-import org.springframework.http.MediaType
-import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.server.RouterFunction
-import org.springframework.web.util.UriComponentsBuilder
-import javax.mail.internet.ContentDisposition
-import javax.mail.internet.MimeMultipart
-import javax.mail.util.ByteArrayDataSource
 
-class WebFluxTarget(private val routerFunction: RouterFunction<*>) : TestTarget {
-  override fun getProviderInfo(serviceName: String, pactSource: PactSource?) = ProviderInfo(serviceName)
-
+class WebFluxTarget(private val routerFunction: RouterFunction<*>) : WebFluxBasedTestTarget {
   override fun prepareRequest(interaction: Interaction, context: MutableMap<String, Any>): Pair<WebTestClient.RequestHeadersSpec<*>, WebTestClient> {
     if (interaction is SynchronousRequestResponse) {
       val request = interaction.request.generatedRequest(context, GeneratorTestMode.Provider)
       val webClient = WebTestClient.bindToRouterFunction(routerFunction).build()
       return toWebFluxRequestBuilder(webClient, request) to webClient
     }
-    throw UnsupportedOperationException("Only request/response interactions can be used with an MockMvc test target")
-  }
-
-  private fun toWebFluxRequestBuilder(webClient: WebTestClient, request: IRequest): WebTestClient.RequestHeadersSpec<*> {
-    return if (request.body.isPresent()) {
-      if (request.isMultipartFileUpload()) {
-        val multipart = MimeMultipart(ByteArrayDataSource(request.body.unwrap(), request.contentTypeHeader()))
-
-        val bodyBuilder = MultipartBodyBuilder()
-        var i = 0
-        while (i < multipart.count) {
-          val bodyPart = multipart.getBodyPart(i)
-          val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
-          val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
-          val filename = contentDisposition.getParameter("filename").orEmpty()
-
-          bodyBuilder
-            .part(name, bodyPart.content)
-            .filename(filename)
-            .contentType(MediaType.valueOf(bodyPart.contentType))
-            .header("Content-Disposition", "form-data; name=$name; filename=$filename")
-
-          i++
-        }
-
-        webClient
-          .method(HttpMethod.POST)
-          .uri(requestUriString(request))
-          .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
-          .headers { request.headers.forEach { (k, v) -> it.addAll(k, v) } }
-      } else {
-        webClient
-          .method(HttpMethod.valueOf(request.method))
-          .uri(requestUriString(request))
-          .bodyValue(request.body.value!!)
-          .headers {
-            request.headers.forEach { (k, v) -> it.addAll(k, v) }
-            if (!request.headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
-              it.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            }
-          }
-      }
-    } else {
-      webClient
-        .method(HttpMethod.valueOf(request.method))
-        .uri(requestUriString(request))
-        .headers {
-          request.headers.forEach { (k, v) -> it.addAll(k, v) }
-        }
-    }
-  }
-
-  private fun requestUriString(request: IRequest): String {
-    val uriBuilder = UriComponentsBuilder.fromPath(request.path)
-
-    request.query.forEach { (key, value) ->
-      uriBuilder.queryParam(key, value)
-    }
-
-    return uriBuilder.toUriString()
-  }
-
-  override fun isHttpTarget() = true
-
-  override fun executeInteraction(client: Any?, request: Any?): ProviderResponse {
-    val requestBuilder = request as WebTestClient.RequestHeadersSpec<*>
-    val exchangeResult = requestBuilder.exchange().expectBody().returnResult()
-
-    val headers = mutableMapOf<String, List<String>>()
-    exchangeResult.responseHeaders.forEach { header ->
-      headers[header.key] = header.value
-    }
-
-    val contentTypeHeader = exchangeResult.responseHeaders.contentType
-    val contentType = if (contentTypeHeader == null) {
-      ContentType.JSON
-    } else {
-      ContentType.fromString(contentTypeHeader.toString())
-    }
-
-    return ProviderResponse(
-      exchangeResult.status.value(),
-      headers,
-      contentType,
-      exchangeResult.responseBody?.let { String(it) }
-    )
-  }
-
-  override fun prepareVerifier(verifier: IProviderVerifier, testInstance: Any) {
-    /* NO-OP */
+    throw UnsupportedOperationException("Only request/response interactions can be used with a WebFlux test target")
   }
 }

--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/WebTestClientTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/WebTestClientTarget.kt
@@ -1,0 +1,16 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.core.model.Interaction
+import au.com.dius.pact.core.model.SynchronousRequestResponse
+import au.com.dius.pact.core.model.generators.GeneratorTestMode
+import org.springframework.test.web.reactive.server.WebTestClient
+
+class WebTestClientTarget(private val webTestClient: WebTestClient) : WebFluxBasedTestTarget {
+    override fun prepareRequest(interaction: Interaction, context: MutableMap<String, Any>): Pair<WebTestClient.RequestHeadersSpec<*>, WebTestClient> {
+        if (interaction is SynchronousRequestResponse) {
+            val request = interaction.request.generatedRequest(context, GeneratorTestMode.Provider)
+            return toWebFluxRequestBuilder(webTestClient, request) to webTestClient
+        }
+        throw UnsupportedOperationException("Only request/response interactions can be used with a WebFlux test target")
+    }
+}

--- a/provider/junit5spring/src/test/groovy/au/com/dius/pact/provider/spring/junit5/WebTestClientTargetSpec.groovy
+++ b/provider/junit5spring/src/test/groovy/au/com/dius/pact/provider/spring/junit5/WebTestClientTargetSpec.groovy
@@ -1,0 +1,84 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.core.model.OptionalBody
+import au.com.dius.pact.core.model.Request
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.server.RequestPredicates
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.ServerResponse
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+import static org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFunction
+
+@SuppressWarnings('ClosureAsLastMethodParameter')
+class WebTestClientTargetSpec extends Specification {
+  RouterFunction routerFunction = RouterFunctions.route(RequestPredicates.GET('/data'), { req ->
+    ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
+      .body(BodyInserters.fromValue('{"id":1234}'))
+  })
+
+  def 'should prepare get request'() {
+    given:
+    WebTestClientTarget webTestClientTarget = new WebTestClientTarget(bindToRouterFunction(routerFunction).build())
+    def request = new Request('GET', '/data', [id: ['1234']])
+    def interaction = new RequestResponseInteraction('some description', [], request)
+
+    when:
+    def requestAndClient = webTestClientTarget.prepareRequest(interaction, [:])
+    def requestBuilder = requestAndClient.first
+    def builtRequest = requestBuilder.exchange().expectBody().returnResult()
+
+    then:
+    requestBuilder instanceof WebTestClient.RequestHeadersSpec
+    builtRequest.url.path == '/data'
+    builtRequest.method.toString() == 'GET'
+    new String(builtRequest.responseBody) == '{"id":1234}'
+  }
+
+  def 'should prepare post request'() {
+    given:
+    RouterFunction postRouterFunction = RouterFunctions.route(RequestPredicates.POST('/data'), { req ->
+      assert req.queryParams() == [id: ['1234']]
+      def reqBody = req.bodyToMono(String).doOnNext({ s -> assert s == '{"foo":"bar"}' })
+      ServerResponse.ok().build(reqBody)
+    })
+    WebTestClientTarget webTestClientTarget = new WebTestClientTarget(bindToRouterFunction(postRouterFunction).build())
+    def request = new Request('POST', '/data', [id: ['1234']], [:],
+            OptionalBody.body('{"foo":"bar"}'.getBytes(StandardCharsets.UTF_8)))
+    def interaction = new RequestResponseInteraction('some description', [], request)
+
+    when:
+    def requestAndClient = webTestClientTarget.prepareRequest(interaction, [:])
+    def requestBuilder = requestAndClient.first
+
+    then:
+    requestBuilder instanceof WebTestClient.RequestHeadersSpec
+    def builtRequest = requestBuilder.exchange().expectBody().returnResult()
+    builtRequest.url.path == '/data'
+    builtRequest.method.toString() == 'POST'
+    builtRequest.rawStatusCode == 200
+  }
+
+  def 'should execute interaction'() {
+    given:
+    def request = new Request('GET', '/data', [id: ['1234']])
+    def interaction = new RequestResponseInteraction('some description', [], request)
+    WebTestClientTarget webTestClientTarget = new WebTestClientTarget(bindToRouterFunction(routerFunction).build())
+    def requestAndClient = webTestClientTarget.prepareRequest(interaction, [:])
+    def requestBuilder = requestAndClient.first
+
+    when:
+    def response = webTestClientTarget.executeInteraction(requestAndClient.second, requestBuilder)
+
+    then:
+    response.statusCode == 200
+    response.contentType.toString() == 'application/json'
+    response.body == '{"id":1234}'
+  }
+}

--- a/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/WebTestClientPactTest.java
+++ b/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/WebTestClientPactTest.java
@@ -1,0 +1,50 @@
+package au.com.dius.pact.provider.spring.junit5;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.*;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Provider("myAwesomeService")
+@PactFolder("pacts")
+class WebTestClientPactTest {
+
+  public static class Handler {
+    public Mono<ServerResponse> handleRequest(ServerRequest request) {
+      return ServerResponse.noContent().build();
+    }
+  }
+
+  static class Router {
+    public RouterFunction<ServerResponse> route(Handler handler) {
+      return RouterFunctions
+        .route(RequestPredicates.GET("/data").and(RequestPredicates.accept(MediaType.APPLICATION_JSON)),
+          handler::handleRequest)
+        .andRoute(RequestPredicates.GET("/async-data").and(RequestPredicates.accept(MediaType.APPLICATION_JSON)),
+          handler::handleRequest);
+    }
+  }
+
+  @BeforeEach
+  void setup(PactVerificationContext context) {
+    Handler handler = new Handler();
+    WebTestClient webTestClient = WebTestClient.bindToRouterFunction(new Router().route(handler)).build();
+    context.setTarget(new WebTestClientTarget(webTestClient));
+  }
+
+  @TestTemplate
+  @ExtendWith(PactVerificationSpringProvider.class)
+  void pactVerificationTestTemplate(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+}


### PR DESCRIPTION
Added support for TestClient as a test target.
Refactored the code where WebFluxTarget and WebTestClientTarget shares a common base class WebFluxBasedTestTarget.