### PR TITLE
feat: Publish verification results with provider branch

### DIFF
--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
@@ -158,6 +158,20 @@ interface IPactBrokerClient {
   ): Result<Boolean, List<String>>
 
   /**
+   * Publish provider branch to the Pact broker
+   * @param docAttributes Attributes associated with the fetched Pact file
+   * @param tag Provider name
+   * @param branch Provider branch
+   * @param version Provider version
+   */
+  fun publishProviderBranch(
+    docAttributes: Map<String, Any?>,
+    name: String,
+    branch: String,
+    version: String
+  ): Result<Boolean, List<String>>
+
+  /**
    * Publishes the result to the "pb:publish-verification-results" link in the document attributes.
    */
   fun publishVerificationResults(
@@ -565,6 +579,35 @@ open class PactBrokerClient(
     }
   }
 
+  override fun publishProviderBranch(
+    docAttributes: Map<String, Any?>,
+    name: String,
+    branch: String,
+    version: String
+  ): Result<Boolean, List<String>> {
+    try {
+      val halClient = newHalClient()
+        .withDocContext(docAttributes)
+        .navigate(PROVIDER)
+      val result = halClient.putJson(PROVIDER_BRANCH_VERSION, mapOf("version" to version, "branch" to branch), "{}")
+      when (result) {
+        is Ok<*> -> {
+          logger.debug { "Pushed branch $branch for provider $name and version $version" }
+          return Ok(true)
+        }
+        is Err<Exception> -> {
+          logger.error(result.error) { "Failed to push branch $branch for provider $name and version $version" }
+          return Err(listOf("Publishing branch '$branch' failed: ${result.error.message ?: result.error.toString()}"))
+        }
+      }
+
+    } catch (e: NotFoundHalResponse) {
+      val message = "Could not create branch for provider $name, link was missing. It looks like your Pact Broker does not support branches, please update to Pact Broker version 2.86.0 or later for branch support"
+      logger.error(e) { message }
+      return Err(listOf(message))
+    }
+  }
+
   @JvmOverloads
   open fun canIDeploy(
     pacticipant: String,
@@ -616,6 +659,7 @@ open class PactBrokerClient(
     const val BETA_PROVIDER_PACTS_FOR_VERIFICATION = "beta:provider-pacts-for-verification"
     const val PROVIDER = "pb:provider"
     const val PROVIDER_TAG_VERSION = "pb:version-tag"
+    const val PROVIDER_BRANCH_VERSION = "pb:branch-version"
     const val PACTS = "pb:pacts"
     const val UTF8 = "UTF-8"
 

--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
@@ -146,7 +146,7 @@ interface IPactBrokerClient {
   /**
    * Publish all the tags for the provider to the Pact broker
    * @param docAttributes Attributes associated with the fetched Pact file
-   * @param tag Provider name
+   * @param name Provider name
    * @param tags Provider tags to tag the provider with
    * @param version Provider version
    */
@@ -160,7 +160,7 @@ interface IPactBrokerClient {
   /**
    * Publish provider branch to the Pact broker
    * @param docAttributes Attributes associated with the fetched Pact file
-   * @param tag Provider name
+   * @param name Provider name
    * @param branch Provider branch
    * @param version Provider version
    */
@@ -169,7 +169,7 @@ interface IPactBrokerClient {
     name: String,
     branch: String,
     version: String
-  ): Result<Boolean, List<String>>
+  ): Result<Boolean, String>
 
   /**
    * Publishes the result to the "pb:publish-verification-results" link in the document attributes.
@@ -584,7 +584,7 @@ open class PactBrokerClient(
     name: String,
     branch: String,
     version: String
-  ): Result<Boolean, List<String>> {
+  ): Result<Boolean, String> {
     try {
       val halClient = newHalClient()
         .withDocContext(docAttributes)
@@ -597,14 +597,14 @@ open class PactBrokerClient(
         }
         is Err<Exception> -> {
           logger.error(result.error) { "Failed to push branch $branch for provider $name and version $version" }
-          return Err(listOf("Publishing branch '$branch' failed: ${result.error.message ?: result.error.toString()}"))
+          return Err("Publishing branch '$branch' failed: ${result.error.message ?: result.error.toString()}")
         }
       }
 
     } catch (e: NotFoundHalResponse) {
       val message = "Could not create branch for provider $name, link was missing. It looks like your Pact Broker does not support branches, please update to Pact Broker version 2.86.0 or later for branch support"
       logger.error(e) { message }
-      return Err(listOf(message))
+      return Err(message)
     }
   }
 

--- a/provider/gradle/README.md
+++ b/provider/gradle/README.md
@@ -103,6 +103,7 @@ The following project properties must be specified as system properties:
 |`pact.verifier.disableUrlPathDecoding`|Disables decoding of request paths|
 |`pact.pactbroker.httpclient.usePreemptiveAuthentication`|Enables preemptive authentication with the pact broker when set to `true`|
 |`pact.provider.tag`|Sets the provider tag to push before publishing verification results (can use a comma separated list)|
+|`pact.provider.branch`|Sets the provider branch to push before publishing verification results|
 |`pact.content_type.override.<TYPE>.<SUBTYPE>=<VAL>` where `<VAL>` may be `text`, `json` or `binary`|Overrides the handling of a particular content type [4.1.3+]|
 |`pact.verifier.enableRedirectHandling`|Enables automatically handling redirects [4.1.8+]|
 |`pact.verifier.generateDiff`|Controls the generation of diffs. Can be set to `true`, `false` or a size threshold (for instance `1mb` or `100kb`) which only enables diffs for payloads of size less than that [4.2.7+]|

--- a/provider/junit/README.md
+++ b/provider/junit/README.md
@@ -600,6 +600,13 @@ you need set the `pact.provider.tag` JVM system property to the tag value.
 From 4.1.8+, you can specify multiple tags with a comma separated string for the `pact.provider.tag`
 system property.
 
+## Setting the provider branch before verification results are published [4.3.0-beta.7+]
+
+Pact Broker version 2.86.0 or later
+
+You can have a branch pushed against the provider version before the verification results are published. To do this
+you need set the `pact.provider.branch` JVM system property to the branch value.
+
 # Pending Pact Support (version 4.1.3 and later)
 
 If your Pact broker supports pending pacts, you can enable support for that by enabling that on your Pact broker annotation or with JVM system properties. You also need to provide the tags that will be published with your provider's verification results. The broker will then label any pacts found that don't have a successful verification result as pending. That way, if they fail verification, the verifier will ignore those failures and not fail the build.

--- a/provider/maven/README.md
+++ b/provider/maven/README.md
@@ -802,6 +802,13 @@ you need set the `pact.provider.tag` JVM system property to the tag value.
 From 4.1.8+, you can specify multiple tags with a comma separated string for the `pact.provider.tag`
 system property.
 
+## Setting the provider branch before verification results are published [4.3.0-beta.7+]
+
+Requires Pact Broker version 2.86.0 or later
+
+You can have a branch pushed against the provider version before the verification results are published. To do this
+you need set the `pact.provider.branch` JVM system property to the branch value.
+
 # Enabling other verification reports
 
 By default the verification report is written to the console. You can also enable a JSON or Markdown report by setting

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderInfo.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderInfo.kt
@@ -108,7 +108,11 @@ open class ProviderInfo @JvmOverloads constructor (
   }
 
   open fun pactBrokerClient(pactBrokerUrl: String, options: PactBrokerOptions): PactBrokerClient {
-    return PactBrokerClient(pactBrokerUrl, options.toMutableMap(), PactBrokerClientConfig(insecureTLS = options.insecureTLS))
+    return PactBrokerClient(
+      pactBrokerUrl,
+      options.toMutableMap(),
+      PactBrokerClientConfig(insecureTLS = options.insecureTLS)
+    )
   }
 
   @Suppress("TooGenericExceptionThrown")

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
@@ -837,7 +837,12 @@ open class ProviderVerifier @JvmOverloads constructor (
           VerificationResult.Ok()
         }
         else -> {
-          val reportResults = reportResults(pact, result, client)
+          val reportResults = verificationReporter.reportResults(pact,
+            result.toTestResult(),
+            providerVersion.get(),
+            client,
+            providerTags?.get().orEmpty(),
+            providerBranch?.get().orEmpty())
           when (reportResults) {
             is Ok -> VerificationResult.Ok()
             is Err -> VerificationResult.Failed("Failed to publish results to the Pact broker", "",
@@ -845,30 +850,6 @@ open class ProviderVerifier @JvmOverloads constructor (
           }
         }
       })
-    }
-  }
-
-  private fun reportResults(
-      pact: FilteredPact,
-      result: VerificationResult,
-      client: IPactBrokerClient?
-  ): Result<Boolean, List<String>> {
-    if (providerBranch?.get()?.isNotBlank() == true){
-      return verificationReporter.reportResultsWithBranch(
-        pact,
-        result.toTestResult(),
-        providerVersion.get(),
-        client,
-        providerBranch?.get()
-      )
-    } else {
-      return verificationReporter.reportResults(
-        pact,
-        result.toTestResult(),
-        providerVersion.get(),
-        client,
-        providerTags?.get().orEmpty()
-      )
     }
   }
 

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/StateChange.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/StateChange.kt
@@ -95,7 +95,7 @@ object DefaultStateChange : StateChange, KLogging() {
     return StateChangeResult(stateChangeResult, message)
   }
 
-  @Suppress("TooGenericExceptionCaught")
+  @Suppress("TooGenericExceptionCaught", "ReturnCount")
   override fun stateChange(
     verifier: IProviderVerifier,
     state: ProviderState,
@@ -167,7 +167,12 @@ object DefaultStateChange : StateChange, KLogging() {
       response?.use {
         if (response.code >= 400) {
           verifier.reporters.forEach {
-            it.stateChangeRequestFailed(state.name.toString(), provider, isSetup, "${response.code} ${response.reasonPhrase}")
+            it.stateChangeRequestFailed(
+              state.name.toString(),
+              provider,
+              isSetup,
+              "${response.code} ${response.reasonPhrase}"
+            )
           }
           Err(Exception("State Change Request Failed - ${response.code} ${response.reasonPhrase}"))
         } else {

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/TestResultAccumulator.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/TestResultAccumulator.kt
@@ -85,7 +85,10 @@ object DefaultTestResultAccumulator : TestResultAccumulator, KLogging() {
         Ok(false)
       } else {
         val initial = TestResult.Ok(interaction.interactionId)
-        reportResults(pact, interactionResults, initial, propertyResolver)
+        verificationReporter.reportResults(pact, interactionResults.values.fold(initial) { acc: TestResult, result ->
+          acc.merge(result)
+        }, lookupProviderVersion(propertyResolver), null, lookupProviderTags(propertyResolver),
+          lookupProviderBranch(propertyResolver))
       }
       testResults.remove(pactHash)
       result
@@ -95,23 +98,6 @@ object DefaultTestResultAccumulator : TestResultAccumulator, KLogging() {
         logger.warn { "    ${it.description}" }
       }
       Ok(true)
-    }
-  }
-
-  private fun reportResults(
-    pact: Pact,
-    interactionResults: MutableMap<Int, TestResult>,
-    initial: TestResult.Ok,
-    propertyResolver: ValueResolver
-  ): Result<Boolean, List<String>> {
-    if (lookupProviderBranch(propertyResolver)?.isNotBlank() == true){
-      return verificationReporter.reportResultsWithBranch(pact, interactionResults.values.fold(initial) { acc: TestResult, result ->
-        acc.merge(result)
-      }, lookupProviderVersion(propertyResolver), null, lookupProviderBranch(propertyResolver))
-    } else {
-      return verificationReporter.reportResults(pact, interactionResults.values.fold(initial) { acc: TestResult, result ->
-        acc.merge(result)
-      }, lookupProviderVersion(propertyResolver), null, lookupProviderTags(propertyResolver))
     }
   }
 

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationReporter.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationReporter.kt
@@ -31,25 +31,17 @@ interface VerificationReporter {
   )
 
   /**
-   * Publish the results to the pact broker. If the tags are given, then the provider will be tagged with those first.
+   * Publish the results to the pact broker.
+   * If the branch is given, then branch for this provider will be created first.
+   * If the tags are given, then the provider will be tagged with those after the branch si created.
    */
   fun reportResults(
     pact: Pact,
     result: TestResult,
     version: String,
     client: IPactBrokerClient? = null,
-    tags: List<String> = emptyList()
-  ): Result<Boolean, List<String>>
-
-  /**
-   * Publish the results to the pact broker. If the branch is given, then branch for this provider will be created first.
-   */
-  fun reportResultsWithBranch(
-    pact: Pact,
-    result: TestResult,
-    version: String,
-    client: IPactBrokerClient? = null,
-    branch: String?
+    tags: List<String> = emptyList(),
+    branch: String? = null
   ): Result<Boolean, List<String>>
 
   /**
@@ -88,33 +80,14 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
     result: TestResult,
     version: String,
     client: IPactBrokerClient?,
-    tags: List<String>
-  ): Result<Boolean, List<String>> {
-    return when (val source = pact.source) {
-      is BrokerUrlSource -> {
-        val brokerClient = client ?: PactBrokerClient(source.pactBrokerUrl, source.options.toMutableMap(),
-          PactBrokerClientConfig())
-        publishResultWithTags(brokerClient, source, result, version, pact, tags)
-      }
-      else -> {
-        logger.info { "Skipping publishing verification results for source $source" }
-        Ok(false)
-      }
-    }
-  }
-
-  override fun reportResultsWithBranch(
-    pact: Pact,
-    result: TestResult,
-    version: String,
-    client: IPactBrokerClient?,
+    tags: List<String>,
     branch: String?
   ): Result<Boolean, List<String>> {
     return when (val source = pact.source) {
       is BrokerUrlSource -> {
         val brokerClient = client ?: PactBrokerClient(source.pactBrokerUrl, source.options.toMutableMap(),
           PactBrokerClientConfig())
-        publishResultWithBranch(brokerClient, source, result, version, pact, branch)
+        publishResult(brokerClient, source, result, version, pact, tags, branch)
       }
       else -> {
         logger.info { "Skipping publishing verification results for source $source" }
@@ -123,12 +96,13 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
     }
   }
 
-  private fun publishResultWithBranch(
+  private fun publishResult(
     brokerClient: IPactBrokerClient,
     source: BrokerUrlSource,
     result: TestResult,
     version: String,
     pact: Pact,
+    tags: List<String>,
     branch: String?
   ): Result<Boolean, List<String>> {
     val branchResult = if (branch?.isNotBlank() == true) {
@@ -136,45 +110,27 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
     } else {
       Ok(true)
     }
-    return publishResults(brokerClient, source, result, version, pact, branchResult)
-  }
-
-  private fun publishResultWithTags(
-    brokerClient: IPactBrokerClient,
-    source: BrokerUrlSource,
-    result: TestResult,
-    version: String,
-    pact: Pact,
-    tags: List<String>
-  ): Result<Boolean, List<String>> {
     val tagsResult = if (tags.isNotEmpty()) {
       brokerClient.publishProviderTags(source.attributes, pact.provider.name, tags, version)
     } else {
       Ok(true)
     }
-    return publishResults(brokerClient, source, result, version, pact, tagsResult)
-  }
-
-  private fun publishResults(
-      brokerClient: IPactBrokerClient,
-      source: BrokerUrlSource,
-      result: TestResult,
-      version: String,
-      pact: Pact,
-      branchResult: Result<Boolean, List<String>>
-  ): Result<Boolean, List<String>> {
     val publishResult = brokerClient.publishVerificationResults(source.attributes, result, version)
     if (publishResult is Err) {
       logger.error { "Failed to publish verification results - ${publishResult.error}" }
-      } else {
+    } else {
       logger.info { "Published verification result of '$result' for consumer '${pact.consumer}'" }
-      }
+    }
 
     return when {
-      branchResult is Err && publishResult is Ok -> branchResult
-      branchResult is Err && publishResult is Err -> Err(branchResult.error + publishResult.error)
+      tagsResult is Err && branchResult is Ok && publishResult is Ok -> tagsResult
+      branchResult is Err && tagsResult is Ok && publishResult is Ok -> branchResult.mapError { listOf(it) }
+      tagsResult is Err && branchResult is Err && publishResult is Ok -> Err(
+        tagsResult.error + branchResult.error)
+      tagsResult is Err && branchResult is Err && publishResult is Err -> Err(
+        tagsResult.error + branchResult.error + publishResult.error)
       else -> publishResult.mapError { listOf(it) }
-      }
+    }
   }
 
   override fun publishingResultsDisabled() = publishingResultsDisabled(SystemPropertyResolver)

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationReporter.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationReporter.kt
@@ -42,6 +42,17 @@ interface VerificationReporter {
   ): Result<Boolean, List<String>>
 
   /**
+   * Publish the results to the pact broker. If the branch is given, then branch for this provider will be created first.
+   */
+  fun reportResultsWithBranch(
+    pact: Pact,
+    result: TestResult,
+    version: String,
+    client: IPactBrokerClient? = null,
+    branch: String?
+  ): Result<Boolean, List<String>>
+
+  /**
    * This must return true unless the pact.verifier.publishResults property has the value of "true"
    */
   @Deprecated("Use version that takes a value resolver")
@@ -83,7 +94,7 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
       is BrokerUrlSource -> {
         val brokerClient = client ?: PactBrokerClient(source.pactBrokerUrl, source.options.toMutableMap(),
           PactBrokerClientConfig())
-        publishResult(brokerClient, source, result, version, pact, tags)
+        publishResultWithTags(brokerClient, source, result, version, pact, tags)
       }
       else -> {
         logger.info { "Skipping publishing verification results for source $source" }
@@ -92,7 +103,43 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
     }
   }
 
-  private fun publishResult(
+  override fun reportResultsWithBranch(
+    pact: Pact,
+    result: TestResult,
+    version: String,
+    client: IPactBrokerClient?,
+    branch: String?
+  ): Result<Boolean, List<String>> {
+    return when (val source = pact.source) {
+      is BrokerUrlSource -> {
+        val brokerClient = client ?: PactBrokerClient(source.pactBrokerUrl, source.options.toMutableMap(),
+          PactBrokerClientConfig())
+        publishResultWithBranch(brokerClient, source, result, version, pact, branch)
+      }
+      else -> {
+        logger.info { "Skipping publishing verification results for source $source" }
+        Ok(false)
+      }
+    }
+  }
+
+  private fun publishResultWithBranch(
+    brokerClient: IPactBrokerClient,
+    source: BrokerUrlSource,
+    result: TestResult,
+    version: String,
+    pact: Pact,
+    branch: String?
+  ): Result<Boolean, List<String>> {
+    val branchResult = if (branch?.isNotBlank() == true) {
+      brokerClient.publishProviderBranch(source.attributes, pact.provider.name, branch, version)
+    } else {
+      Ok(true)
+    }
+    return publishResults(brokerClient, source, result, version, pact, branchResult)
+  }
+
+  private fun publishResultWithTags(
     brokerClient: IPactBrokerClient,
     source: BrokerUrlSource,
     result: TestResult,
@@ -105,18 +152,29 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
     } else {
       Ok(true)
     }
+    return publishResults(brokerClient, source, result, version, pact, tagsResult)
+  }
+
+  private fun publishResults(
+      brokerClient: IPactBrokerClient,
+      source: BrokerUrlSource,
+      result: TestResult,
+      version: String,
+      pact: Pact,
+      branchResult: Result<Boolean, List<String>>
+  ): Result<Boolean, List<String>> {
     val publishResult = brokerClient.publishVerificationResults(source.attributes, result, version)
     if (publishResult is Err) {
       logger.error { "Failed to publish verification results - ${publishResult.error}" }
-    } else {
+      } else {
       logger.info { "Published verification result of '$result' for consumer '${pact.consumer}'" }
-    }
+      }
 
     return when {
-      tagsResult is Err && publishResult is Ok -> tagsResult
-      tagsResult is Err && publishResult is Err -> Err(tagsResult.error + publishResult.error)
+      branchResult is Err && publishResult is Ok -> branchResult
+      branchResult is Err && publishResult is Err -> Err(branchResult.error + publishResult.error)
       else -> publishResult.mapError { listOf(it) }
-    }
+      }
   }
 
   override fun publishingResultsDisabled() = publishingResultsDisabled(SystemPropertyResolver)

--- a/provider/src/test/groovy/au/com/dius/pact/provider/ProviderVerifierSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/ProviderVerifierSpec.groovy
@@ -445,7 +445,7 @@ class ProviderVerifierSpec extends Specification {
     verifier.runVerificationForConsumer([:], provider, consumer, pactBrokerClient)
 
     then:
-    1 * verifier.verificationReporter.reportResults(_, finalResult, '0.0.0', pactBrokerClient, tags) >> new Ok(true)
+    1 * verifier.verificationReporter.reportResults(_, finalResult, '0.0.0', pactBrokerClient, tags, _) >> new Ok(true)
     1 * verifier.verifyResponseFromProvider(provider, interaction1, _, _, _, _, false) >> result1
     1 * verifier.verifyResponseFromProvider(provider, interaction2, _, _, _, _, false) >> result2
 
@@ -493,7 +493,7 @@ class ProviderVerifierSpec extends Specification {
     verifier.runVerificationForConsumer([:], provider, consumer, pactBrokerClient)
 
     then:
-    1 * verifier.verificationReporter.reportResultsWithBranch(_, finalResult, '0.0.0', pactBrokerClient, branch) >> new Ok(true)
+    1 * verifier.verificationReporter.reportResults(_, finalResult, '0.0.0', pactBrokerClient, [], branch) >> new Ok(true)
     1 * verifier.verifyResponseFromProvider(provider, interaction1, _, _, _, _, false) >> result1
     1 * verifier.verifyResponseFromProvider(provider, interaction2, _, _, _, _, false) >> result2
 
@@ -535,7 +535,7 @@ class ProviderVerifierSpec extends Specification {
     def result = verifier.runVerificationForConsumer([:], provider, consumer, pactBrokerClient)
 
     then:
-    1 * verifier.verificationReporter.reportResults(_, _, '0.0.0', pactBrokerClient, []) >> new Err(['failed'])
+    1 * verifier.verificationReporter.reportResults(_, _, '0.0.0', pactBrokerClient, [], _) >> new Err(['failed'])
     1 * verifier.verifyResponseFromProvider(provider, interaction1, _, _, _, _, false) >> new VerificationResult.Ok()
     1 * verifier.verifyResponseFromProvider(provider, interaction2, _, _, _, _, false) >> new VerificationResult.Ok()
     result instanceof VerificationResult.Failed

--- a/provider/src/test/groovy/au/com/dius/pact/provider/ProviderVerifierSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/ProviderVerifierSpec.groovy
@@ -413,7 +413,7 @@ class ProviderVerifierSpec extends Specification {
   @Unroll
   @SuppressWarnings('UnnecessaryGetter')
   @RestoreSystemProperties
-  def 'after verifying a pact, the results are reported back using reportVerificationResults'() {
+  def 'after verifying a pact, the results are reported back using tags and reportVerificationResults'() {
     given:
     ProviderInfo provider = new ProviderInfo('Test Provider')
     ConsumerInfo consumer = new ConsumerInfo(name: 'Test Consumer', pactSource: UnknownPactSource.INSTANCE)
@@ -446,6 +446,54 @@ class ProviderVerifierSpec extends Specification {
 
     then:
     1 * verifier.verificationReporter.reportResults(_, finalResult, '0.0.0', pactBrokerClient, tags) >> new Ok(true)
+    1 * verifier.verifyResponseFromProvider(provider, interaction1, _, _, _, _, false) >> result1
+    1 * verifier.verifyResponseFromProvider(provider, interaction2, _, _, _, _, false) >> result2
+
+    where:
+
+    result1                         | result2                         | finalResult
+    new VerificationResult.Ok()     | new VerificationResult.Ok()     | new TestResult.Ok()
+    new VerificationResult.Ok()     | new VerificationResult.Failed() | new TestResult.Failed()
+    new VerificationResult.Failed() | new VerificationResult.Ok()     | new TestResult.Failed()
+    new VerificationResult.Failed() | new VerificationResult.Failed() | new TestResult.Failed()
+  }
+
+  @Unroll
+  @SuppressWarnings('UnnecessaryGetter')
+  @RestoreSystemProperties
+  def 'after verifying a pact, the results are reported back using branch and reportVerificationResults'() {
+    given:
+    ProviderInfo provider = new ProviderInfo('Test Provider')
+    ConsumerInfo consumer = new ConsumerInfo(name: 'Test Consumer', pactSource: UnknownPactSource.INSTANCE)
+    PactBrokerClient pactBrokerClient = Mock(PactBrokerClient, constructorArgs: [''])
+    verifier.verificationReporter = Mock(VerificationReporter)
+    verifier.pactReader = Stub(PactReader)
+    def statechange = Stub(StateChange) {
+      executeStateChange(*_) >> new StateChangeResult(new Ok([:]))
+    }
+    def interaction1 = Stub(RequestResponseInteraction)
+    def interaction2 = Stub(RequestResponseInteraction)
+    def mockPact = Stub(Pact) {
+      getSource() >> new BrokerUrlSource('http://localhost', 'http://pact-broker')
+    }
+
+    verifier.projectHasProperty = { it == ProviderVerifier.PACT_VERIFIER_PUBLISH_RESULTS }
+    verifier.projectGetProperty = {
+      (it == ProviderVerifier.PACT_VERIFIER_PUBLISH_RESULTS).toString()
+    }
+    verifier.stateChangeHandler = statechange
+
+    verifier.pactReader.loadPact(_) >> mockPact
+    mockPact.interactions >> [interaction1, interaction2]
+
+    def branch = "master"
+    System.setProperty(ProviderVerifier.PACT_PROVIDER_BRANCH, branch)
+
+    when:
+    verifier.runVerificationForConsumer([:], provider, consumer, pactBrokerClient)
+
+    then:
+    1 * verifier.verificationReporter.reportResultsWithBranch(_, finalResult, '0.0.0', pactBrokerClient, branch) >> new Ok(true)
     1 * verifier.verifyResponseFromProvider(provider, interaction1, _, _, _, _, false) >> result1
     1 * verifier.verifyResponseFromProvider(provider, interaction2, _, _, _, _, false) >> result2
 

--- a/provider/src/test/groovy/au/com/dius/pact/provider/TestResultAccumulatorSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/TestResultAccumulatorSpec.groovy
@@ -100,7 +100,7 @@ class TestResultAccumulatorSpec extends Specification {
     testResultAccumulator.updateTestResult(mutablePact, interaction3, new TestResult.Ok(), null, mockValueResolver)
 
     then:
-    1 * mockVerificationReporter.reportResults(_, new TestResult.Ok(), _, null, [])
+    1 * mockVerificationReporter.reportResults(_, new TestResult.Ok(), _, null, [], _)
 
     cleanup:
     testResultAccumulator.verificationReporter = DefaultVerificationReporter.INSTANCE
@@ -144,7 +144,7 @@ class TestResultAccumulatorSpec extends Specification {
       mockValueResolver)
 
     then:
-    1 * testResultAccumulator.verificationReporter.reportResults(_, result, _, _, _) >> new Ok(true)
+    1 * testResultAccumulator.verificationReporter.reportResults(_, result, _, _, _, _) >> new Ok(true)
     updateTestResult == new Ok(true)
 
     cleanup:
@@ -172,7 +172,7 @@ class TestResultAccumulatorSpec extends Specification {
     testResultAccumulator.updateTestResult(pact, interaction2, interaction2Result, null, mockValueResolver)
 
     then:
-    1 * testResultAccumulator.verificationReporter.reportResults(_, result, _, _, _)
+    1 * testResultAccumulator.verificationReporter.reportResults(_, result, _, _, _, _)
 
     cleanup:
     testResultAccumulator.verificationReporter = reporter
@@ -204,7 +204,7 @@ class TestResultAccumulatorSpec extends Specification {
     testResultAccumulator.updateTestResult(pact, interaction2, new TestResult.Ok(), null, mockValueResolver)
 
     then:
-    1 * testResultAccumulator.verificationReporter.reportResults(_, failedResult, _, _, _)
+    1 * testResultAccumulator.verificationReporter.reportResults(_, failedResult, _, _, _, _)
 
     cleanup:
     testResultAccumulator.verificationReporter = reporter
@@ -226,7 +226,7 @@ class TestResultAccumulatorSpec extends Specification {
     testResultAccumulator.updateTestResult(pact, interaction2, new TestResult.Ok(), null, mockValueResolver)
 
     then:
-    1 * testResultAccumulator.verificationReporter.reportResults(_, new TestResult.Ok(), _, _, _)
+    1 * testResultAccumulator.verificationReporter.reportResults(_, new TestResult.Ok(), _, _, _, _)
     testResultAccumulator.testResults.isEmpty()
 
     cleanup:
@@ -252,7 +252,7 @@ class TestResultAccumulatorSpec extends Specification {
 
     then:
     1 * testResultAccumulator.verificationReporter.reportResults(_, new TestResult.Ok(), _, _,
-      ['updateTestResultTag'])
+      ['updateTestResultTag'], _)
     testResultAccumulator.testResults.isEmpty()
 
     cleanup:
@@ -278,7 +278,7 @@ class TestResultAccumulatorSpec extends Specification {
 
     then:
     1 * testResultAccumulator.verificationReporter.reportResults(_, new TestResult.Ok(), _, _,
-      ['tag1', 'tag2', 'tag3'])
+      ['tag1', 'tag2', 'tag3'], _)
     testResultAccumulator.testResults.isEmpty()
 
     cleanup:
@@ -406,7 +406,7 @@ class TestResultAccumulatorSpec extends Specification {
     verificationReporter.publishingResultsDisabled(_) >> false
     1 * verificationReporter.reportResults(pact2,
       new TestResult.Ok(['interaction2_3', 'interaction2_1', 'interaction2_4', 'interaction2_2'] as HashSet), _, _,
-      [])
+      [], _)
     1 * verificationReporter.reportResults(pact3,
       new TestResult.Failed(
         [
@@ -415,14 +415,14 @@ class TestResultAccumulatorSpec extends Specification {
           [interactionId: 'interaction2_2'],
           [interactionId: 'interaction2_3']
         ], 'failed'), _, _,
-      [])
+      [], _)
     1 * verificationReporter.reportResults(pact4,
       new TestResult.Ok(['interaction3_1', 'interaction3_2', 'interaction3_3', 'interaction3_4'] as HashSet), _, _,
-      [])
+      [], _)
     1 * verificationReporter.reportResults(pact1,
       new TestResult.Ok(
         ['interaction1_1', 'interaction1_2', 'interaction1_3', 'interaction1_4', 'interaction1_5'] as HashSet
-      ), _, _, [])
+      ), _, _, [], _)
     0 * verificationReporter._
     testResultAccumulator.testResults.isEmpty()
 
@@ -447,7 +447,7 @@ class TestResultAccumulatorSpec extends Specification {
       mockValueResolver)
 
     then:
-    1 * testResultAccumulator.verificationReporter.reportResults(_, new TestResult.Ok(), _, _, _) >>
+    1 * testResultAccumulator.verificationReporter.reportResults(_, new TestResult.Ok(), _, _, _, _) >>
       new Err('failed')
     testResultAccumulator.testResults.isEmpty()
     result1 instanceof Ok


### PR DESCRIPTION
Hi,
this PR implements #1454 

I tested it on the latest pact broker:
Publish pacts
`pact-broker publish --consumer-app-version 1 --broker-base-url http://localhost:9292 ./pacts --branch master`
Run verification tests and publish results
```
mvn clean test -Dpactbroker.url=http://localhost:9292 -Dpactbroker.consumerversionselectors.rawjson=[{\"mainBranch\":true},{\"deployedOrReleased\":true}] -Dpact.provider.version=1 -Dpact.provider.branch=master -Dpact.verifier.publishResults=true -Dpactbroker.enablePending=true -Dpactbroker.providerTags=master
```

Results were published and provider `master` branch was created in pact broker.

See screenshot of the matrix:
![provider_branch](https://user-images.githubusercontent.com/2538092/141092039-0bda48bf-ef0b-45ae-b434-2988a8f754d1.png)


@bethesque 
In the old broker, I used to define selectors with tags this way `-Dpactbroker.consumerversionselectors.tags=master,stage`
In the raw json selectors format, what is an equivalent value to `master,stage` given that `stage` is a no-production environment used with `record-deployment` command?
Based on examples from [documentation](https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/#advanced), I have got something like this:
```
[
   {
      "mainBranch":true
   },
   {
      "deployed":true,
      "environment":"stage"
   }
]
```
or if I want to specify the exact branch
```
[
   {
      "branch":"master"
   },
   {
      "deployed":true,
      "environment":"stage"
   }
]
```
Another use case is "I am in a feature branch and I want to verify my provider build only against stage consumers", is this json correct?
```
[
   {
      "deployed":true,
      "environment":"stage"
   }
]
```
Thanks