### PR TITLE
Support asynchronous message V4 specification in JUnit5 provider

### DIFF
--- a/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/TestTarget.kt
+++ b/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/TestTarget.kt
@@ -6,7 +6,7 @@ import au.com.dius.pact.core.model.PactBrokerSource
 import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.model.SynchronousRequestResponse
 import au.com.dius.pact.core.model.generators.GeneratorTestMode
-import au.com.dius.pact.core.model.messaging.Message
+import au.com.dius.pact.core.model.messaging.MessageInteraction
 import au.com.dius.pact.provider.ConsumerInfo
 import au.com.dius.pact.provider.HttpClientFactory
 import au.com.dius.pact.provider.IHttpClientFactory
@@ -178,7 +178,7 @@ open class MessageTestTarget @JvmOverloads constructor(
   }
 
   override fun prepareRequest(interaction: Interaction, context: MutableMap<String, Any>): Pair<Any, Any>? {
-    if (interaction is Message) {
+    if (interaction is MessageInteraction) {
       return null
     }
     throw UnsupportedOperationException("Only message interactions can be used with an AMPQ test target")

--- a/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/AmqpContractTest.java
+++ b/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/AmqpContractTest.java
@@ -34,9 +34,13 @@ class AmqpContractTest {
     LOGGER.info("SomeProviderState callback");
   }
 
-  @PactVerifyProvider("a test message")
+  @PactVerifyProvider("a V3 test message")
   public String verifyMessageForOrder() {
     return "{\"testParam1\": \"value1\",\"testParam2\": \"value2\"}";
   }
 
+  @PactVerifyProvider("a V4 test message")
+  public String verifyV4MessageForOrder() {
+    return "{\"testParam1\": \"value1\",\"testParam2\": \"value2\"}";
+  }
 }

--- a/provider/junit5/src/test/resources/amqp_pacts/message_test_consumer-test_provider_v4.json
+++ b/provider/junit5/src/test/resources/amqp_pacts/message_test_consumer-test_provider_v4.json
@@ -5,9 +5,9 @@
     "provider": {
         "name": "AmqpProvider"
     },
-    "messages": [
+    "interactions": [
         {
-            "description": "a V3 test message",
+            "description": "a V4 test message",
             "metaData": {
                 "contentType": "application/json"
             },
@@ -15,15 +15,17 @@
                 "testParam1": "value1",
                 "testParam2": "value2"
             },
-            "providerState": "SomeProviderState"
+            "providerState": "SomeProviderState",
+            "pending": false,
+            "type": "Asynchronous/Messages"
         }
     ],
     "metadata": {
         "pact-specification": {
-            "version": "3.0.0"
+            "version": "4.0"
         },
         "pact-jvm": {
-            "version": "3.3.3"
+            "version": "4.3.0"
         }
     }
 }


### PR DESCRIPTION
We noticed that JUnit5 provider was not able to handle asynchronous message pacts when using V4 specification. This was down to `MessageTestTarget` expecting interaction to be of type `Message`, but V4 asynchronous messages don't inherit from that class. Instead they implement `MessageInteraction` which `Message` also implements.

This changeset allows supporting both V3 and V4 specifications because the request in both cases is recognised as `MessageInteraction`.