### PR TITLE
Specify buildUrl with system property pact.verifier.buildUrl

### DIFF
--- a/provider/gradle/README.md
+++ b/provider/gradle/README.md
@@ -107,6 +107,7 @@ The following project properties must be specified as system properties:
 |`pact.content_type.override.<TYPE>.<SUBTYPE>=<VAL>` where `<VAL>` may be `text`, `json` or `binary`|Overrides the handling of a particular content type [4.1.3+]|
 |`pact.verifier.enableRedirectHandling`|Enables automatically handling redirects [4.1.8+]|
 |`pact.verifier.generateDiff`|Controls the generation of diffs. Can be set to `true`, `false` or a size threshold (for instance `1mb` or `100kb`) which only enables diffs for payloads of size less than that [4.2.7+]|
+|`pact.verifier.buildUrl`|Specifies buildUrl to report to the broker when publishing verification results [4.3.2+]|
 
 ## Specifying the provider hostname at runtime
 
@@ -889,6 +890,8 @@ For pacts that are loaded from a Pact Broker, the results of running the verific
  broker against the URL for the pact. You will be able to see the result on the Pact Broker home screen.
 
 To turn on the verification publishing, set the project property `pact.verifier.publishResults` to `true`.
+
+To provide the build URL, set the JVM system property `pact.verifier.buildUrl`.
 
 By default, the Gradle project version will be used as the provider version. You can override this by setting the
 `providerVersion` property.

--- a/provider/junit/README.md
+++ b/provider/junit/README.md
@@ -607,6 +607,11 @@ Pact Broker version 2.86.0 or later
 You can have a branch pushed against the provider version before the verification results are published. To do this
 you need set the `pact.provider.branch` JVM system property to the branch value.
 
+## Setting the build URL for verification results [4.3.2+]
+
+You can specify a URL to link to your CI build output. To do this you need to set the `pact.verifier.buildUrl` JVM
+system property to the URL value.
+
 # Pending Pact Support (version 4.1.3 and later)
 
 If your Pact broker supports pending pacts, you can enable support for that by enabling that on your Pact broker annotation or with JVM system properties. You also need to provide the tags that will be published with your provider's verification results. The broker will then label any pacts found that don't have a successful verification result as pending. That way, if they fail verification, the verifier will ignore those failures and not fail the build.

--- a/provider/junit5/README.md
+++ b/provider/junit5/README.md
@@ -193,6 +193,41 @@ calculation for payloads that exceed this size.
 For instance, setting `pact.verifier.generateDiff=false` will turn off the generation of diffs for all bodies, while
 `pact.verifier.generateDiff=512kb` will only turn off the diffs if the actual or expected body is larger than 512kb.
 
+# Publishing verification results to a Pact Broker
+
+For pacts that are loaded from a Pact Broker, the results of running the verification can be published back to the
+broker against the URL for the pact. You will be able to see the result on the Pact Broker home screen. You need to
+set the version of the provider that is verified using the `pact.provider.version` system property.
+
+To enable publishing of results, set the Java system property or environment variable `pact.verifier.publishResults` to `true`.
+
+### IMPORTANT NOTE!!!: this property needs to be set on the test JVM if your build is running with Gradle or Maven.
+
+Gradle and Maven do not pass in the system properties in to the test JVM from the command line. The system properties
+specified on the command line only control the build JVM (the one that runs Gradle or Maven), but the tests will run in
+a new JVM. See [Maven Surefire Using System Properties](https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html)
+and [Gradle Test docs](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:systemProperties).
+
+## Tagging the provider before verification results are published [4.0.1+]
+
+You can have a tag pushed against the provider version before the verification results are published. To do this
+you need set the `pact.provider.tag` JVM system property to the tag value.
+
+From 4.1.8+, you can specify multiple tags with a comma separated string for the `pact.provider.tag`
+system property.
+
+## Setting the provider branch before verification results are published [4.3.0-beta.7+]
+
+Pact Broker version 2.86.0 or later
+
+You can have a branch pushed against the provider version before the verification results are published. To do this
+you need set the `pact.provider.branch` JVM system property to the branch value.
+
+## Setting the build URL for verification results [4.3.2+]
+
+You can specify a URL to link to your CI build output. To do this you need to set the `pact.verifier.buildUrl` JVM
+system property to the URL value.
+
 # Pending Pact Support (version 4.1.0 and later)
 
 If your Pact broker supports pending pacts, you can enable support for that by enabling that on your Pact broker annotation or with JVM system properties. You also need to provide the tags that will be published with your provider's verification results. The broker will then label any pacts found that don't have a successful verification result as pending. That way, if they fail verification, the verifier will ignore those failures and not fail the build.

--- a/provider/maven/README.md
+++ b/provider/maven/README.md
@@ -299,6 +299,7 @@ The following plugin properties can be specified with `-Dproperty=value` on the 
 |`pact.content_type.override.<TYPE>.<SUBTYPE>=text\|json\|binary`|Overrides the handling of a particular content type [version 4.1.3+]|
 |`pact.verifier.enableRedirectHandling`|Enables automatically handling redirects [4.1.8+]|
 |`pact.verifier.generateDiff`|Controls the generation of diffs. Can be set to `true`, `false` or a size threshold (for instance `1mb` or `100kb`) which only enables diffs for payloads of size less than that [4.2.7+]|
+|`pact.verifier.buildUrl`|Specifies buildUrl to report to the broker when publishing verification results [4.3.2+]|
 
 Example in the configuration section:
 
@@ -808,6 +809,11 @@ Requires Pact Broker version 2.86.0 or later
 
 You can have a branch pushed against the provider version before the verification results are published. To do this
 you need set the `pact.provider.branch` JVM system property to the branch value.
+
+## Setting the build URL for verification results [4.3.2+]
+
+You can specify a URL to link to your CI build output. To do this you need to set the `pact.verifier.buildUrl` JVM
+system property to the URL value.
 
 # Enabling other verification reports
 

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
@@ -965,6 +965,7 @@ open class ProviderVerifier @JvmOverloads constructor (
 
   companion object : KLogging() {
     const val PACT_VERIFIER_PUBLISH_RESULTS = "pact.verifier.publishResults"
+    const val PACT_VERIFIER_BUILD_URL = "pact.verifier.buildUrl"
     const val PACT_FILTER_CONSUMERS = "pact.filter.consumers"
     const val PACT_FILTER_DESCRIPTION = "pact.filter.description"
     const val PACT_FILTER_PROVIDERSTATE = "pact.filter.providerState"

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationReporter.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/VerificationReporter.kt
@@ -115,7 +115,12 @@ object DefaultVerificationReporter : VerificationReporter, KLogging() {
     } else {
       Ok(true)
     }
-    val publishResult = brokerClient.publishVerificationResults(source.attributes, result, version)
+    val buildUrl = System.getProperty(ProviderVerifier.PACT_VERIFIER_BUILD_URL)
+    val publishResult = if (buildUrl.isNullOrEmpty()) {
+      brokerClient.publishVerificationResults(source.attributes, result, version)
+    } else {
+      brokerClient.publishVerificationResults(source.attributes, result, version, buildUrl)
+    }
     if (publishResult is Err) {
       logger.error { "Failed to publish verification results - ${publishResult.error}" }
     } else {


### PR DESCRIPTION
buildUrl is an optional value when publishing verification results, but there's currently no way to set it using JUnit or (as far as I can tell) any of the other pact-jvm provider verification publication approaches.

This PR proposes a new system property `pact.verifier.buildUrl` which can be set when publishing verification results to specify the buildUrl value.

See https://docs.pact.io/pact_broker/advanced_topics/api_docs/publish_verification_result/

Fixes #1482