### PR TITLE
fix: use system default parameters on basic-auth

### DIFF
--- a/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/HalClientSpec.groovy
+++ b/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/HalClientSpec.groovy
@@ -4,8 +4,8 @@ import au.com.dius.pact.core.support.json.JsonParser
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import org.apache.hc.client5.http.classic.methods.HttpPost
-import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider
 import org.apache.hc.client5.http.impl.auth.BasicScheme
+import org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.RedirectExec
 import org.apache.hc.client5.http.protocol.RedirectStrategy
@@ -61,7 +61,7 @@ class HalClientSpec extends Specification {
     client.setupHttpClient()
 
     then:
-    client.httpClient.credentialsProvider instanceof BasicCredentialsProvider
+    client.httpClient.credentialsProvider instanceof SystemDefaultCredentialsProvider
     client.httpContext == null
   }
 
@@ -76,7 +76,7 @@ class HalClientSpec extends Specification {
     client.setupHttpClient()
 
     then:
-    client.httpClient.credentialsProvider instanceof BasicCredentialsProvider
+    client.httpClient.credentialsProvider instanceof SystemDefaultCredentialsProvider
     client.httpContext != null
     client.httpContext.authCache.get(host) instanceof BasicScheme
   }

--- a/core/support/src/main/kotlin/au/com/dius/pact/core/support/HttpClient.kt
+++ b/core/support/src/main/kotlin/au/com/dius/pact/core/support/HttpClient.kt
@@ -8,7 +8,6 @@ import org.apache.hc.client5.http.auth.AuthScope
 import org.apache.hc.client5.http.auth.CredentialsProvider
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials
 import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy
-import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider
 import org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder
@@ -121,7 +120,7 @@ object HttpClient : KLogging() {
     password: String,
     builder: HttpClientBuilder
   ): CredentialsProvider {
-    val credsProvider = BasicCredentialsProvider()
+    val credsProvider = SystemDefaultCredentialsProvider()
     credsProvider.setCredentials(AuthScope(uri.host, uri.port),
       UsernamePasswordCredentials(username, password.toCharArray()))
     builder.setDefaultCredentialsProvider(credsProvider)


### PR DESCRIPTION
fixes [[#478](https://github.com/pact-foundation/pact-jvm/issues/478)]

Using the `SystemDefaultCredentialsProvider` enables proxy authentication from system-properties when using basic authentication. 