### PR TITLE
Include verification results url output from can i deploy task

### DIFF
--- a/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/PactBrokerClientSpec.groovy
+++ b/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/PactBrokerClientSpec.groovy
@@ -737,7 +737,7 @@ class PactBrokerClientSpec extends Specification {
     1 * mockHalClient.postJson(PactBrokerClient.PUBLISH_CONTRACTS_LINK, [:], jsonBody) >> new Ok(new JsonValue.Object([:]))
   }
 
-  @Issue('#')
+  @Issue('#1525')
   def 'can-i-deploy - should return verificationResultUrl when there is one'() {
     given:
     def halClient = Mock(IHalClient)

--- a/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactCanIDeployTask.groovy
+++ b/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactCanIDeployTask.groovy
@@ -58,6 +58,10 @@ class PactCanIDeployTask extends PactCanIDeployBaseTask {
       println("Computer says no ¯\\_(ツ)_/¯ ${result.message}\n\n${t.red.invoke(result.reason)}")
     }
 
+    if (result.verificationResultUrl != null) {
+      println("VERIFICATION RESULTS\n--------------------\n1. ${result.verificationResultUrl}\n")
+    }
+
     if (!result.ok) {
       throw new GradleScriptException("Can you deploy? Computer says no ¯\\_(ツ)_/¯ ${result.message}", null)
     }

--- a/provider/gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactCanIDeployTaskSpec.groovy
+++ b/provider/gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactCanIDeployTaskSpec.groovy
@@ -76,7 +76,7 @@ class PactCanIDeployTaskSpec extends Specification {
     project.evaluate()
 
     task.brokerClient = Mock(PactBrokerClient) {
-      canIDeploy(_, _, _, _, _) >> new CanIDeployResult(true, '', '', null)
+      canIDeploy(_, _, _, _, _) >> new CanIDeployResult(true, '', '', null, null)
     }
 
     when:
@@ -105,7 +105,31 @@ class PactCanIDeployTaskSpec extends Specification {
     then:
     notThrown(GradleScriptException)
     1 * task.brokerClient.canIDeploy('pacticipant', '1.0.0', _, _, _) >>
-      new CanIDeployResult(true, '', '', null)
+      new CanIDeployResult(true, '', '', null, null)
+  }
+
+  def 'prints verification results url when pact broker client returns one'() {
+    given:
+    project.pact {
+      broker {
+        pactBrokerUrl = 'pactBrokerUrl'
+      }
+    }
+    project.ext.pacticipant = 'pacticipant'
+    project.ext.pacticipantVersion = '1.0.0'
+    project.ext.latest = 'true'
+    project.ext.toTag = 'prod'
+    project.evaluate()
+
+    task.brokerClient = Mock(PactBrokerClient)
+
+    when:
+    task.canIDeploy()
+
+    then:
+    notThrown(GradleScriptException)
+    1 * task.brokerClient.canIDeploy('pacticipant', '1.0.0',
+      new Latest.UseLatest(true), 'prod', _) >> new CanIDeployResult(true, '', '', null, 'verificationResultUrl')
   }
 
   def 'passes optional parameters to the pact broker client'() {
@@ -129,7 +153,7 @@ class PactCanIDeployTaskSpec extends Specification {
     then:
     notThrown(GradleScriptException)
     1 * task.brokerClient.canIDeploy('pacticipant', '1.0.0',
-      new Latest.UseLatest(true), 'prod', _) >> new CanIDeployResult(true, '', '', null)
+      new Latest.UseLatest(true), 'prod', _) >> new CanIDeployResult(true, '', '', null, null)
   }
 
   def 'throws an exception if the pact broker client says no'() {
@@ -150,7 +174,7 @@ class PactCanIDeployTaskSpec extends Specification {
 
     then:
     1 * task.brokerClient.canIDeploy('pacticipant', '1.0.0', _, _, _) >>
-      new CanIDeployResult(false, 'Bad version', 'Bad version', null)
+      new CanIDeployResult(false, 'Bad version', 'Bad version', null, null)
     def ex = thrown(GradleScriptException)
     ex.message == 'Can you deploy? Computer says no ¯\\_(ツ)_/¯ Bad version'
   }

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCanIDeployMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactCanIDeployMojo.kt
@@ -59,6 +59,10 @@ open class PactCanIDeployMojo : PactBaseMojo() {
       println("Computer says no ¯\\_(ツ)_/¯ ${result.message}\n\n${t.red(result.reason)}")
     }
 
+    if (result.verificationResultUrl != null) {
+      println("VERIFICATION RESULTS\n--------------------\n1. ${result.verificationResultUrl}\n")
+    }
+
     if (!result.ok) {
       throw MojoExecutionException("Can you deploy? Computer says no ¯\\_(ツ)_/¯ ${result.message}", null)
     }

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCanIDeployMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCanIDeployMojoSpec.groovy
@@ -113,6 +113,22 @@ class PactCanIDeployMojoSpec extends Specification {
       new Latest.UseLatest(true), '', selectors) >> new CanIDeployResult(true, '', '', null, null)
   }
 
+  def 'prints verification results url when pact broker client returns one'() {
+    given:
+    IgnoreSelector[] selectors = [new IgnoreSelector('bob')] as IgnoreSelector[]
+    mojo.latest = 'true'
+    mojo.ignore = selectors
+    mojo.brokerClient = Mock(PactBrokerClient)
+
+    when:
+    mojo.execute()
+
+    then:
+    notThrown(MojoExecutionException)
+    1 * mojo.brokerClient.canIDeploy('test', '1234',
+      new Latest.UseLatest(true), '', selectors) >> new CanIDeployResult(true, '', '', null, "verificationResultUrl")
+  }
+
   def 'throws an exception if the pact broker client says no'() {
     given:
     mojo.brokerClient = Mock(PactBrokerClient)

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCanIDeployMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactCanIDeployMojoSpec.groovy
@@ -59,7 +59,7 @@ class PactCanIDeployMojoSpec extends Specification {
     mojo.pacticipantVersion = null
     mojo.latest = 'true'
     mojo.brokerClient = Mock(PactBrokerClient) {
-      canIDeploy(_, _, _, _, _) >> new CanIDeployResult(true, '', '', null)
+      canIDeploy(_, _, _, _, _) >> new CanIDeployResult(true, '', '', null, null)
     }
 
     when:
@@ -79,7 +79,7 @@ class PactCanIDeployMojoSpec extends Specification {
     then:
     notThrown(MojoExecutionException)
     1 * mojo.brokerClient.canIDeploy('test', '1234', _, _, _) >>
-      new CanIDeployResult(true, '', '', null)
+      new CanIDeployResult(true, '', '', null, null)
   }
 
   def 'passes optional parameters to the pact broker client'() {
@@ -94,7 +94,7 @@ class PactCanIDeployMojoSpec extends Specification {
     then:
     notThrown(MojoExecutionException)
     1 * mojo.brokerClient.canIDeploy('test', '1234',
-      new Latest.UseLatest(true), 'prod', _) >> new CanIDeployResult(true, '', '', null)
+      new Latest.UseLatest(true), 'prod', _) >> new CanIDeployResult(true, '', '', null, null)
   }
 
   def 'passes ignore parameters to the pact broker client'() {
@@ -110,7 +110,7 @@ class PactCanIDeployMojoSpec extends Specification {
     then:
     notThrown(MojoExecutionException)
     1 * mojo.brokerClient.canIDeploy('test', '1234',
-      new Latest.UseLatest(true), '', selectors) >> new CanIDeployResult(true, '', '', null)
+      new Latest.UseLatest(true), '', selectors) >> new CanIDeployResult(true, '', '', null, null)
   }
 
   def 'throws an exception if the pact broker client says no'() {
@@ -122,7 +122,7 @@ class PactCanIDeployMojoSpec extends Specification {
 
     then:
     1 * mojo.brokerClient.canIDeploy('test', '1234', _, _, _) >>
-      new CanIDeployResult(false, 'Bad version', 'Bad version', null)
+      new CanIDeployResult(false, 'Bad version', 'Bad version', null, null)
     def ex = thrown(MojoExecutionException)
     ex.message == 'Can you deploy? Computer says no ¯\\_(ツ)_/¯ Bad version'
   }


### PR DESCRIPTION
Fixes #1525 

From looking at the can i deploy code that is called from the client, it calls the /matrix api with parameters from the can i deploy parameters. After playing around with the matrix api, it appears that the verification results url is returned inside of the first entry in the matrix field in format
```
"verificationResult": {
        "success": false,
        "verifiedAt": "2022-03-16T18:13:56+00:00",
        "_links": {
          "self": {
            "href": "https://workday.pactflow.io/pacts/provider/admiral/consumer/tuocs/pact-version/4f1c177b57868a3bc7e5eac39e45b8f4c3713039/metadata/Y3ZuPTAuMC4xJTJCMzgyMTdhYQ/verification-results/3227"
          }
        }
      }
```
(href being the verification results url above)

This PR adds this url inside of of the Can I Deploy result data class (defaulted to null) that the client returns from calling can i deploy, and only adds it if it is able to find this field with many null safety checks. If it finds it, then the task (both in gradle and maven), will print it out in the same format that the Ruby version does, i.e.
```
VERIFICATION RESULTS
--------------------
1. https://pact-broker/pacts/provider/Bar/consumer/Foo/pact-version/cc4e5ae3c12482c6ffd87c4018090a7a1524c634/metadata/Y3ZuPTMzNzFmN2Y5MQ/verification-results/375 (success)
```