### PR TITLE
docs: remove links to java8 guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You want to look at: [pact4s](https://github.com/jbwheatley/pact4s) or [scala-pa
 
 You want to look at: [junit](consumer/junit) for JUnit 4 tests and
 [junit5](consumer/junit5) for JUnit 5 tests. Also, if you are using Java 11 or above, there is [an
-updated DSL for consumer tests](https://github.com/pact-foundation/pact-jvm/tree/master/consumer).
+updated DSL for consumer tests](/consumer).
 
 **NOTE:** If you are using Java 8, there is no separate Java 8 support library anymore, see the above library.
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,11 @@ You want to look at: [pact4s](https://github.com/jbwheatley/pact4s) or [scala-pa
 ### I Use Java
 
 You want to look at: [junit](consumer/junit) for JUnit 4 tests and
-[junit5](consumer/junit5) for JUnit 5 tests. Also, if you are using Java 8 or above, there is [an
-updated DSL for consumer tests](consumer/java8).
+[junit5](consumer/junit5) for JUnit 5 tests. Also, if you are using Java 11 or above, there is [an
+updated DSL for consumer tests](https://github.com/pact-foundation/pact-jvm/tree/master/consumer).
+
+**NOTE:** If you are using Java 8, there is no separate Java 8 support library anymore, see the above library.
+
 
 ### I Use Groovy or Grails
 

--- a/consumer/junit/README.md
+++ b/consumer/junit/README.md
@@ -347,7 +347,9 @@ is verified. It is only recorded in the consumer tests and used by the provider 
 
 ### Building JSON bodies with PactDslJsonBody DSL
 
-**NOTE:** If you are using Java 8, there is [an updated DSL for consumer tests](/consumer/java8/README.md).
+:::note
+If you are using Java 8, there is no separate Java 8 support library anymore, there is [an updated DSL for consumer tests](/consumer/)
+requiring a minimum of Java 11.
 
 The body method of the ConsumerPactBuilder can accept a PactDslJsonBody, which can construct a JSON body as well as
 define regex and type matchers.

--- a/consumer/junit/README.md
+++ b/consumer/junit/README.md
@@ -347,9 +347,7 @@ is verified. It is only recorded in the consumer tests and used by the provider 
 
 ### Building JSON bodies with PactDslJsonBody DSL
 
-:::note
-If you are using Java 8, there is no separate Java 8 support library anymore, there is [an updated DSL for consumer tests](/consumer/)
-requiring a minimum of Java 11.
+**NOTE:** If you are using Java 8, there is no separate Java 8 support library anymore, there is [an updated DSL for consumer tests](/consumer/) requiring a minimum of Java 11.
 
 The body method of the ConsumerPactBuilder can accept a PactDslJsonBody, which can construct a JSON body as well as
 define regex and type matchers.


### PR DESCRIPTION
close https://github.com/pact-foundation/docs.pact.io/issues/138

- update junit guide to point to new pact consumer


We may also need to update

https://github.com/pact-foundation/pact-jvm/blob/master/README.md?plain=1#L53

https://github.com/pact-foundation/pact-jvm/blob/ba271ad904883dc50bf6a2770f0df2a993575702/README.md?plain=1#L77