### PR TITLE
feat: Add support for enabling insecure TLS to the PactBrokerLoader to the 4.1.x branch.

### DIFF
--- a/provider/junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/provider/junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -8,6 +8,8 @@ import au.com.dius.pact.core.pactbroker.IPactBrokerClient
 import au.com.dius.pact.core.pactbroker.InvalidHalResponse
 import au.com.dius.pact.core.pactbroker.InvalidNavigationRequest
 import au.com.dius.pact.core.pactbroker.PactBrokerResult
+import au.com.dius.pact.core.support.expressions.DataType
+import au.com.dius.pact.core.support.expressions.ExpressionParser
 import au.com.dius.pact.core.support.expressions.SystemPropertyResolver
 import au.com.dius.pact.core.support.expressions.ValueResolver
 import au.com.dius.pact.provider.junitsupport.loader.VersionSelector
@@ -45,6 +47,7 @@ class PactBrokerLoaderSpec extends Specification {
   private Pact mockPact
   private PactReader mockReader
   private ValueResolver valueResolver
+  private String enableInsecureTls
 
   void setup() {
     host = 'pactbroker'
@@ -65,11 +68,13 @@ class PactBrokerLoaderSpec extends Specification {
       loadPact(_) >> mockPact
     }
     valueResolver = null
+    enableInsecureTls = ''
 
     pactBrokerLoader = { boolean failIfNoPactsFound = true ->
       IPactBrokerClient client = brokerClient
       def loader = new PactBrokerLoader(host, port, protocol, tags, consumerVersionSelectors, consumers,
-        failIfNoPactsFound, null, null, valueResolver, enablePendingPacts, providerTags, includeWipPactsSince, url) {
+        failIfNoPactsFound, null, null, valueResolver, enablePendingPacts, providerTags, includeWipPactsSince, url,
+              enableInsecureTls) {
         @Override
         IPactBrokerClient newPactBrokerClient(URI url, ValueResolver resolver) {
           client
@@ -1261,6 +1266,84 @@ class PactBrokerLoaderSpec extends Specification {
     thrown(InvalidNavigationRequest)
   }
 
+  void 'Does not enable insecure TLS when not set in PactBroker annotation and not using the fallback system property'() {
+    given:
+    pactBrokerLoader = {
+      new PactBrokerLoader(FullPactBrokerAnnotation.getAnnotation(PactBroker)) {
+        @Override
+        IPactBrokerClient newPactBrokerClient(URI url, ValueResolver resolver) {
+          assert !ExpressionParser.parseExpression(enableInsecureTls, DataType.BOOLEAN, resolver) as Boolean
+          brokerClient
+        }
+      }
+    }
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    result == []
+    1 * brokerClient.fetchConsumersWithSelectors('test', _, _, _, _) >> new Ok([])
+  }
+
+  void 'Enables insecure TLS from explicit PactBroker annotation setting'() {
+    given:
+    pactBrokerLoader = {
+      new PactBrokerLoader(EnableInsecureTlsPactBrokerAnnotation.getAnnotation(PactBroker)) {
+        @Override
+        IPactBrokerClient newPactBrokerClient(URI url, ValueResolver resolver) {
+          assert ExpressionParser.parseExpression(enableInsecureTls, DataType.BOOLEAN, resolver) as Boolean
+          brokerClient
+        }
+      }
+    }
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    result == []
+    1 * brokerClient.fetchConsumersWithSelectors('test', _, _, _, _) >> new Ok([])
+  }
+
+  @RestoreSystemProperties
+  void 'Enables insecure TLS using fallback PactBroker annotation system property'() {
+    given:
+    System.setProperty('pactbroker.host', 'my.pactbroker.host')
+    System.setProperty('pactbroker.port', '4711')
+    System.setProperty('pactbroker.enableInsecureTls', 'true')
+    pactBrokerLoader = {
+      new PactBrokerLoader(MinimalPactBrokerAnnotation.getAnnotation(PactBroker)) {
+        @Override
+        IPactBrokerClient newPactBrokerClient(URI url, ValueResolver resolver) {
+          assert ExpressionParser.parseExpression(enableInsecureTls, DataType.BOOLEAN, resolver) as Boolean
+          brokerClient
+        }
+      }
+    }
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    result == []
+    1 * brokerClient.fetchConsumersWithSelectors('test', _, _, _, _) >> new Ok([])
+  }
+
+  def 'Uses the insecure TlS setting when creating the PactBrokerClient'() {
+    given:
+    pactBrokerLoader = {
+      new PactBrokerLoader(EnableInsecureTlsPactBrokerAnnotation.getAnnotation(PactBroker))
+    }
+
+    when:
+    def pactBrokerClient = pactBrokerLoader()
+            .newPactBrokerClient(new URI('http://localhost'), new SystemPropertyResolver())
+
+    then:
+    pactBrokerClient.config.insecureTLS == true
+  }
+
   private static VersionSelector createVersionSelector(Map args = [:]) {
     new VersionSelector() {
       @Override
@@ -1347,6 +1430,11 @@ class PactBrokerLoaderSpec extends Specification {
 
   @PactBroker(host = 'pactbroker.host', port = '1000', tags = 'master')
   static class PactBrokerAnnotationWithTags {
+
+  }
+
+  @PactBroker(host = 'pactbroker.host', port = '1000', enableInsecureTls = 'true')
+  static class EnableInsecureTlsPactBrokerAnnotation {
 
   }
 

--- a/provider/src/main/java/au/com/dius/pact/provider/junitsupport/loader/PactBroker.java
+++ b/provider/src/main/java/au/com/dius/pact/provider/junitsupport/loader/PactBroker.java
@@ -101,4 +101,10 @@ public @interface PactBroker {
    * included.
    */
   String includeWipPactsSince() default "${pactbroker.includeWipPactsSince:}";
+
+  /**
+   * Enabling insecure TLS by setting this to true will disable hostname validation and trust all certificates. Use with caution.
+   * This can be set with the pactbroker.enableInsecureTls JVM system property.
+   */
+  String enableInsecureTls() default "${pactbroker.enableInsecureTls:false}";
 }

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt
@@ -56,7 +56,8 @@ open class PactBrokerLoader(
   val enablePendingPacts: String = "false",
   val providerTags: List<String> = emptyList(),
   val includeWipPactsSince: String = "",
-  val pactBrokerUrl: String? = null
+  val pactBrokerUrl: String? = null,
+  val enableInsecureTls: String = "false"
 ) : OverrideablePactLoader {
 
   private var resolver: ValueResolver? = valueResolver
@@ -79,7 +80,8 @@ open class PactBrokerLoader(
     pactBroker.enablePendingPacts,
     pactBroker.providerTags.toList(),
     pactBroker.includeWipPactsSince,
-    pactBroker.url
+    pactBroker.url,
+    pactBroker.enableInsecureTls
   )
 
   override fun description(): String {
@@ -294,7 +296,8 @@ open class PactBrokerLoader(
 
   open fun newPactBrokerClient(url: URI, resolver: ValueResolver): IPactBrokerClient {
     var options = mapOf<String, Any>()
-    val config = PactBrokerClientConfig()
+    val insecureTls = parseExpression(enableInsecureTls, DataType.BOOLEAN, resolver) as Boolean
+    val config = PactBrokerClientConfig(insecureTLS = insecureTls)
 
     if (authentication == null) {
       logger.debug { "Authentication: None" }


### PR DESCRIPTION
From  PR #1531:

> Currently when verifying Pacts stored on a Pact Broker, insecure TLS can be enabled when running pact:verify using the Maven, Gradle or SBT plugins, but not when running the verification tests with JUnit/JUnit5.
> 
> This feature adds a new property to the PactBroker annotation to allow insecure TLS to be enabled when running the verification tests with JUnit/JUnit5 against Pacts stored on a Pact Broker.

This PR backports that change into the 4.1.x branch.