### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,8 +6,15 @@ on:
   pull_request:
     branches: [ master, v4.1.x, v4.3.x, v4.4.x ]
 
+permissions:
+  contents: read
+
 jobs:
   latest_jdk:
+    permissions:
+      checks: write  # for EnricoMi/publish-unit-test-result-action/composite to check test results
+      contents: read  # for EnricoMi/publish-unit-test-result-action/composite to fetch code
+      issues: read  # for EnricoMi/publish-unit-test-result-action/composite to get issues
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
@@ -36,6 +43,10 @@ jobs:
         files: "**/test-results/**/*.xml"
 
   supported_jdks:
+    permissions:
+      checks: write  # for EnricoMi/publish-unit-test-result-action/composite to check test results
+      contents: read  # for EnricoMi/publish-unit-test-result-action/composite to fetch code
+      issues: read  # for EnricoMi/publish-unit-test-result-action/composite to get issues
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/trigger_pact_docs_update.yml
+++ b/.github/workflows/trigger_pact_docs_update.yml
@@ -7,8 +7,13 @@ on:
     paths:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   run:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs.pact.io update workflow


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
