### PR TITLE
docs: update gradle readme provider states link

### DIFF
--- a/provider/gradle/README.md
+++ b/provider/gradle/README.md
@@ -363,7 +363,7 @@ an override property: `pact.content_type.override.<TYPE>.<SUBTYPE>=text|binary`.
 
 ## Provider States
 
-For a description of what provider states are, see the pact documentations: http://docs.pact.io/documentation/provider_states.html
+For a description of what provider states are, see the pact documentations: https://docs.pact.io/getting_started/provider_states
 
 ### Using a state change URL
 


### PR DESCRIPTION
Update provider state link, as per at least 3 conversation's on slack.

Most recent

https://pact-foundation.slack.com/archives/C01RPBC2KNG/p1653274215754089