### PR TITLE
fix: Don't parse graphql query as a JSON

### DIFF
--- a/core/model/src/main/resources/org/apache/tika/mime/custom-mimetypes.xml
+++ b/core/model/src/main/resources/org/apache/tika/mime/custom-mimetypes.xml
@@ -3,9 +3,6 @@
   <mime-type type="application/x-www-form-urlencoded">
 	  <sub-class-of type="text/plain"/>
   </mime-type>
-  <mime-type type="application/graphql">
-    <sub-class-of type="application/json"/>
-  </mime-type>
   <mime-type type="application/protobuf">
     <sub-class-of type="application/octet-stream"/>
   </mime-type>

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/ContentTypeSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/ContentTypeSpec.groovy
@@ -34,7 +34,7 @@ class ContentTypeSpec extends Specification {
     'application/vnd.schemaregistry.v1+json' || false
     'application/x-thrift'                   || true
     'application/x-other'                    || false
-    'application/graphql'                    || true
+    'application/graphql'                    || false
 
     contentType = new ContentType(value)
   }


### PR DESCRIPTION
Related to issues #1569 and #1371 

In summary: original problem was request body was encoded when content type was application/graphql.
I found out you can always override the content type with property: pact.content_type.override.x.x 

The original ticket  #1371 was closed but the attempt to fix it made it so that the pact tries to parse graphql query as JSON, which it is not. i've raised that issue in #1569