### PR TITLE
docs: Consumer version selector method must be public

### DIFF
--- a/provider/junit5/README.md
+++ b/provider/junit5/README.md
@@ -130,7 +130,7 @@ For example:
 
 ```java
     @au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors
-    static SelectorBuilder consumerVersionSelectors() {
+    public static SelectorBuilder consumerVersionSelectors() {
       // Select Pacts for consumers deployed to production with branch 'FEAT-123' 
       return new SelectorBuilder()
         .environment('production')
@@ -142,7 +142,7 @@ Or for example where the branch is set with the `BRANCH_NAME` environment variab
 
 ```java
     @au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors
-    static SelectorBuilder consumerVersionSelectors() {
+    public static SelectorBuilder consumerVersionSelectors() {
       // Select Pacts for consumers deployed to production with branch from CI build 
       return new SelectorBuilder()
         .environment('production')


### PR DESCRIPTION
Adapt readme to explicitly state that this method must be public (as seen [here](https://github.com/pact-foundation/pact-jvm/blob/a47176118917db6053717c842f6c72cfafc38f84/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt#L385))

I did a small test and figured that Kotlins' `KCallable.visibility` returns `null` for the package protected scope of Java. That's probably due to 

> Visibility of this callable, or null if its visibility cannot be represented in Kotlin.

[source](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-callable/visibility.html)

As I saw this has caused 1 or 2 issues already I thought it's worth a small PR. 

Apart from this small doc change, would you think it makes sense to throw IllegalArgumentException in case the method is invalid in regard to your filter criteria? e.g. I could validate that: 
* method must be public 
* method must contain no params (effectively)
* method must return specific types

So effectively I could split up the current implementation into 2 methods, 1 that just checks if the annotation is present and thats it and another one that validates if its valid and if not, throw `IAE`. 

Would probably help to guide developers a bit.