### PR TITLE
Updated kotlin version from 1.5.31 to 1.6.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version '1.5.31'
+  id 'org.jetbrains.kotlin.jvm' version '1.6.21'
   id 'io.gitlab.arturbosch.detekt' version '1.18.0'
   id 'org.jetbrains.dokka' version '1.5.0' apply false
   id 'org.javamodularity.moduleplugin' version '1.7.0' apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 groovyVersion=3.0.9
-kotlinVersion=1.5.31
+kotlinVersion=1.6.21
 httpBuilderVersion=1.0.4
 commonsLang3Version=3.12.0
 httpClientVersion=5.1


### PR DESCRIPTION
**Problem** : Latest version of pact consumer for junit has a vulnerability CVE-2022-24329
**Reason** : In JetBrains Kotlin before 1.6.0, it was not possible to lock dependencies for Multiplatform Gradle Projects.
**Link** : https://mvnrepository.com/artifact/au.com.dius.pact.consumer/junit/4.3.12

**Fix**
* Updated kotlin jvm version from 1.5.31 to 1.6.21