### PR TITLE
Adding Lambda DSL variants for request/response

### DIFF
--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.kt
@@ -410,6 +410,16 @@ open class PactDslRequestWithPath : PactDslRequestBase {
   }
 
   /**
+   * Variant of [PactDslRequestWithPath.willRespondWith] that introduces a Lambda DSL syntax to better visually
+   * separate request and response in a pact.
+   *
+   * @see PactDslRequestWithPath.willRespondWith
+   * @sample au.com.dius.pact.consumer.dsl.samples.PactLambdaDslSamples.requestResponse
+   */
+  fun willRespondWith(addResponseMatchers: PactDslResponse.() -> PactDslResponse): PactDslResponse =
+    addResponseMatchers(willRespondWith())
+
+  /**
    * Match a query parameter with a regex. A random query parameter value will be generated from the regex
    * if the example value is not provided.
    *

--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.kt
@@ -292,6 +292,18 @@ open class PactDslRequestWithoutPath @JvmOverloads constructor(
   }
 
   /**
+   * Variant of [PactDslRequestWithPath.path] that introduces a Lambda DSL syntax to better visually separate
+   * request and response in a pact.
+   *
+   * @see PactDslRequestWithPath.path
+   * @sample au.com.dius.pact.consumer.dsl.samples.PactLambdaDslSamples.requestResponse
+   */
+  inline fun path(
+    path: String,
+    addRequestMatchers: PactDslRequestWithPath.() -> PactDslRequestWithPath
+  ): PactDslRequestWithPath = addRequestMatchers(path(path))
+
+  /**
    * The path of the request. This will generate a random path to use when generating requests if the example
    * value is not provided.
    *
@@ -310,6 +322,20 @@ open class PactDslRequestWithoutPath @JvmOverloads constructor(
       description, path, requestMethod, requestHeaders, query, requestBody, requestMatchers, requestGenerators,
       defaultRequestValues, defaultResponseValues, comments, version, additionalMetadata)
   }
+
+  /**
+   * Variant of [PactDslRequestWithoutPath.matchPath] that introduces a Lambda DSL syntax to better visually separate
+   * request and response in a pact.
+   *
+   * @see PactDslRequestWithoutPath.matchPath
+   * @sample au.com.dius.pact.consumer.dsl.samples.PactLambdaDslSamples.requestResponse
+   */
+  @JvmOverloads
+  inline fun matchPath(
+    pathRegex: String,
+    path: String = Generex(pathRegex).random(),
+    addRequestMatchers: PactDslRequestWithPath.() -> PactDslRequestWithPath
+  ): PactDslRequestWithPath = addRequestMatchers(matchPath(pathRegex, path))
 
   /**
    * Sets up a file upload request. This will add the correct content type header to the request
@@ -364,6 +390,19 @@ open class PactDslRequestWithoutPath @JvmOverloads constructor(
       description, example, requestMethod, requestHeaders, query, requestBody, requestMatchers, requestGenerators,
       defaultRequestValues, defaultResponseValues, comments, version, additionalMetadata)
   }
+
+  /**
+   * Variant of [PactDslRequestWithoutPath.pathFromProviderState] that introduces a Lambda DSL syntax to better
+   * visually separate request and response in a pact.
+   *
+   * @see PactDslRequestWithoutPath.pathFromProviderState
+   * @sample au.com.dius.pact.consumer.dsl.samples.PactLambdaDslSamples.requestResponse
+   */
+  inline fun pathFromProviderState(
+    expression: String,
+    example: String,
+    addRequestMatchers: PactDslRequestWithPath.() -> PactDslRequestWithPath
+  ): PactDslRequestWithPath = addRequestMatchers(pathFromProviderState(expression, example))
 
   /**
    * Matches a date field using the provided date pattern

--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/samples/PactLambdaDslSamples.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/samples/PactLambdaDslSamples.kt
@@ -1,0 +1,33 @@
+package au.com.dius.pact.consumer.dsl.samples
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.dsl.newJsonObject
+import au.com.dius.pact.core.model.RequestResponsePact
+
+/**
+ * Samples of using Lambda DSL for creating pacts.
+ */
+object PactLambdaDslSamples {
+
+    /**
+     * Shows how Lambda DSL can be used to visually separate the request and the response
+     * section from each other.
+     */
+    fun requestResponse(builder: PactDslWithProvider): RequestResponsePact {
+        return builder.given("no existing users")
+            .uponReceiving("create a new user")
+            .path("users") {
+                // Lambda DSL on request, this: PactDslRequestWithPath
+                headers("X-Locale", "en-US")
+                method("PUT")
+            }.willRespondWith {
+                // Lambda DSL on response, this: PactDslResponse
+                successStatus()
+                body(
+                    newJsonObject {
+                        uuid("name")
+                    }
+                )
+            }.toPact()
+    }
+}


### PR DESCRIPTION
## Overview

This request adds Lambda DSL overloads (as typically preferred in Kotlin) to the request/response sections of defining pacts on consumer side.

```kt
builder.given(/*...*/)
  .uponReceiving(/*...*/)
  .path(/*...*/) {
    /*...*/ // Lambda DSL
  }.willRespondWith {
    /*...*/ // Lambda DSL
  }.toPact()
```

This change has been discussed briefly on Slack and was well received: https://pact-foundation.slack.com/archives/C9UN99H24/p1660207829670959

## Motivation

Originally, we idiomatically wrote the pact in a single chain, typical for builders:
```kt
builder.given("no existing users")
  .uponReceiving("create a new user")
  .path("users")
  .headers("X-Locale", "en-US")
  .method("PUT")
  .willRespondWith()
  .successStatus()
  .body(
    newJsonObject {
      uuid("name")
    }
  ).toPact()
```
The problem this has is that, in particular if using many matchers, it becomes hard to visually spot where the request or response begin or end.

One solution is to manually add indents to the code (as sometimes seen in the Pact documentation):
```kt
builder.given("no existing users")
  .uponReceiving("create a new user")
    .path("users")
    .headers("X-Locale", "en-US")
    .method("PUT")
  .willRespondWith()
    .successStatus()
    .body(
      newJsonObject {
        uuid("name")
      }
  ).toPact()
```
The problem with this otherwise perfect solution is that adding manual indents is not always an option. There are many environments that enforce code styles that do not allow manual indents.

Lambda DSL solves this problem idiomatically and enhances readability of the pact - if manual indents are not an option for an user.

## Minor problem

Ideally, the Lambda DSL for the request would start on `uponReceiving`. The problem with this is that a request can change its type from `PactDslRequestWithoutPath` to `PactDslRequestWithPath`, which makes the DSL hard to get wrong by an unexperienced user. For example, consider:
```kt
builder.given("no existing users")
  .uponReceiving("create a new user") {
    path("users") // this call actually creates a new instance, 'WithPath'
    headers("X-Locale", "en-US") // still operates on 'this', which is 'WithoutPath'
    method("PUT")
    // the pact is now missing the path
  }.willRespondWith {
    /*...*/
  }.toPact()
```

The proper way to write the request in this scenario would be:
```kt
builder.given("no existing users")
  .uponReceiving("create a new user") {
    // chain results on the newly 'WithPath' object, not on 'this'
    path("users")
      .headers("X-Locale", "en-US")
      .method("PUT")
  }.willRespondWith {
    /*...*/
  }.toPact()
```
But this is ugly and misses the point of the DSL that actually wanted to beautify the code.

All in all, there is no satisfying solution to add the DSL on `uponReceiving` already, the type has to be fix. After the request reached `WithPath`, there is no way back anymore, so we can safely add the DSL on this stage.

As long as users start with `path(/*...*/)` before their other matchers, the visual benefit of separating the request from the response is still given. I.e., while valid, it would defeat the purpose if users would write:
```kt
builder.given("no existing users")
  .uponReceiving("create a new user")
  .headers("X-Locale", "en-US") // should be inside the DSL, after path
  .path("users") {
      .method("PUT")
  }.willRespondWith {
    /*...*/
  }.toPact()
```

## Samples

The Lambda DSL variants are best explained with a simple code example. The idiomatic way in Kotlin to have code examples in documentation is `@sample` - that way, the example participates in compilation and does not rot.

It seems that `@sample` was not used in the code base yet, so I had to come up with a proper place to store them. I decided for a new package next to the code that is explained:
![sample package](https://i.imgur.com/b4T2Ja3.png)

Feel free to suggest different locations for samples, if you have better ideas 🙂