### PR TITLE
Fix issue with consumer version selector method being protected

### DIFF
--- a/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/PactBrokerLoaderTest.java
+++ b/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/PactBrokerLoaderTest.java
@@ -1,0 +1,76 @@
+package au.com.dius.pact.provider.spring.junit5;
+
+import org.junit.jupiter.api.Test;
+
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors;
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerLoader;
+import au.com.dius.pact.provider.junitsupport.loader.SelectorBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PactBrokerLoaderTest {
+
+    @Test
+    void test1() {
+        assertNotNull(PactBrokerLoader.testClassHasSelectorsMethod(Test1.class));
+    }
+
+    @Test
+    void test2() {
+        assertThrows(IllegalAccessException.class, () -> PactBrokerLoader.testClassHasSelectorsMethod(Test2.class));
+    }
+
+    @Test
+    void test3() {
+        assertThrows(IllegalAccessException.class, () -> PactBrokerLoader.testClassHasSelectorsMethod(Test3.class));
+    }
+
+    @Test
+    void test4() {
+        assertThrows(IllegalAccessException.class, () -> PactBrokerLoader.testClassHasSelectorsMethod(Test4.class));
+    }
+
+    @Test
+    void test5() {
+        assertNotNull(PactBrokerLoader.testClassHasSelectorsMethod(Test5.class));
+    }
+
+    class Test1 {
+        @PactBrokerConsumerVersionSelectors
+        public static SelectorBuilder cvs() {
+            return new SelectorBuilder();
+        }
+    }
+    class Test2 {
+        @PactBrokerConsumerVersionSelectors
+        static SelectorBuilder cvs() {
+            return new SelectorBuilder();
+        }
+    }
+
+    class Test3 {
+        @PactBrokerConsumerVersionSelectors
+        private static SelectorBuilder cvs() {
+            return new SelectorBuilder();
+        }
+    }
+
+    class Test4 extends Test4Super {}
+
+    class Test4Super {
+        @PactBrokerConsumerVersionSelectors
+        protected static SelectorBuilder cvs() {
+            return new SelectorBuilder();
+        }
+    }
+
+    class Test5 extends Test5Super {}
+
+    class Test5Super {
+        @PactBrokerConsumerVersionSelectors
+        public static SelectorBuilder cvs() {
+            return new SelectorBuilder();
+        }
+    }
+}

--- a/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/PactBrokerLoaderKtTest.kt
+++ b/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/PactBrokerLoaderKtTest.kt
@@ -1,0 +1,98 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerLoader.Companion.testClassHasSelectorsMethod
+import au.com.dius.pact.provider.junitsupport.loader.SelectorBuilder
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class PactBrokerLoaderKtTest {
+
+    @Test
+    fun test1() {
+        assertNotNull(testClassHasSelectorsMethod(Test1::class.java))
+    }
+
+    @Test
+    fun test2() {
+        assertThrows(IllegalAccessException::class.java) {
+            testClassHasSelectorsMethod(Test2::class.java)
+        }
+    }
+
+    @Test
+    fun test3() {
+        assertThrows(IllegalAccessException::class.java) {
+            testClassHasSelectorsMethod(Test3::class.java)
+        }
+    }
+
+    @Test
+    fun test4() {
+        assertThrows(IllegalAccessException::class.java) {
+            testClassHasSelectorsMethod(Test4::class.java)
+        }
+    }
+
+    @Test
+    fun test5() {
+        assertNotNull(testClassHasSelectorsMethod(Test5::class.java))
+    }
+
+    @Test
+    fun test6() {
+        assertNotNull(testClassHasSelectorsMethod(Test6::class.java))
+    }
+
+    class Test1 {
+        @PactBrokerConsumerVersionSelectors
+        fun cvs(): SelectorBuilder {
+            return SelectorBuilder()
+        }
+    }
+
+    class Test2 {
+        @PactBrokerConsumerVersionSelectors
+        private fun cvs(): SelectorBuilder {
+            return SelectorBuilder()
+        }
+    }
+
+    class Test3 {
+        @PactBrokerConsumerVersionSelectors
+        private fun cvs(): SelectorBuilder {
+            return SelectorBuilder()
+        }
+    }
+
+    class Test4 : Test4Super()
+
+    abstract class Test4Super {
+
+        @PactBrokerConsumerVersionSelectors
+        protected fun cvs(): SelectorBuilder {
+            return SelectorBuilder()
+        }
+    }
+
+    class Test5 : Test5Super()
+
+    abstract class Test5Super {
+        @PactBrokerConsumerVersionSelectors
+        fun cvs(): SelectorBuilder {
+            return SelectorBuilder()
+        }
+    }
+
+    class Test6 : Test6Super()
+
+    abstract class Test6Super() {
+        companion object {
+            @PactBrokerConsumerVersionSelectors
+            fun cvs(): SelectorBuilder {
+                return SelectorBuilder()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi,

We've encountered an issue where the consumer version selector method was not picked up by the PACT library and only the `main` branch was checked against without noticing. After investigating I found out that a developer wrote this code: 

```
abstract class AbstractPactTest : AbstractBaseIntegrationTest() {
   
    /* Subclasses may override */
    @PactBrokerConsumerVersionSelectors
    protected fun consumerVersionSelectors(): SelectorBuilder = SelectorBuilder().branch("feature/feat-3996")
```
It doesn't work because the documentation clearly states that the method must be public. However an Exception is supposed to be thrown in this case which is not. People are now wondering why the feat-3996 PACT is not found. I figured that the consumer version selector was not used only by enabling debug logging of the "apache wire" package. 

It would be extremely helpful to always log out the actual used consumer version selector in a human readable way as INFO maybe, so that such issues would come to surface right away.


The reason the IllegalStateException doesn't throw is this: 

`java.lang.Class.getMethods()` 

> Returns an array containing Method objects reflecting all the public methods of the class or interface represented by this Class object, including those declared by the class or interface and those inherited from superclasses and superinterfaces.

Since method is `protected`,  `testClass?.methods` does not return it and validation logic is skipped, because no method is found. 
One solution is to use `getDeclaredMethods()` instead, however this one doesn't check the class hierarchy, so one needs to iterate the hierarchy oneself, which I did now.

I wrote a couple of unit tests and as you can see wasn't really eager to set this up in a super clean way (one should probably use a ParameterizedTest for that..). 

Since this is my first real contribution I hope the CICD runs through. Off for the weekend for now :-)



