### PR TITLE
Bump version of Kotlin Result to work around build failures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@ guavaVersion=30.1.1-jre
 junit5Version=5.7.2
 bytebuddyVersion=1.10.8
 kotlinLogging=2.0.10
-kotlinResult=1.1.12
+kotlinResult=1.1.16
 pluginDriverVersion=0.0.9


### PR DESCRIPTION
On a clean checkout, 

`./gradlew clean build`

fails quite quickly with errors like the following: 

```
> Task :core:support:compileKotlin FAILED
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (4, 38): Unresolved reference: Err
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (5, 38): Unresolved reference: Ok
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (6, 38): Unresolved reference: Result
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (7, 38): Unresolved reference: UnwrapException
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (37, 49): One type argument expected for class Result<out T>
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (40, 25): One type argument expected for class Result<out T>
e: /Users/holly/Code/pact/pact-jvm/core/support/src/main/kotlin/au/com/dius/pact/core/support/KotlinLanguageSupport.kt: (40, 49): One type argument expected for class Result<out T>
```

I don't totally understand the mechanism for why, but bumping the version of michael-bull kotlin-result to the latest version fixes the issues. Being on the latest version may have other advantages. 