### PR TITLE
Use Thread Context ClassLoader to find test resources

### DIFF
--- a/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactFolderLoader.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactFolderLoader.kt
@@ -64,7 +64,7 @@ class PactFolderLoader : PactLoader {
   override fun getPactSource() = this.pactSource
 
   private fun resolvePath(): File {
-    val resourcePath = PactFolderLoader::class.java.classLoader.getResource(path.path)
+    val resourcePath = Thread.currentThread().getContextClassLoader().getResource(path.path)
     return if (resourcePath != null) {
       File(URLDecoder.decode(resourcePath.path, "UTF-8"))
     } else {


### PR DESCRIPTION
Hi! I'm working on improving Pact support in Quarkus (see https://github.com/quarkusio/quarkus/issues/27729). At the moment, Pact provider tests works well when executed via a normal `mvn verify`, but do not work in Quarkus's dev mode. The reason is that in dev mode the classpath is less flat, and so it's no longer safe to assume the `PactLoader` is in the same classloader as the test classes. 

Pact can be made more tolerant to non-flat-classloader hierarchies by switching to use the Thread context classloader for finding resources. This should also improve behaviour in other frameworks.