### PR TITLE
Bump Antlr4 to 4.11.1

### DIFF
--- a/core/model/build.gradle
+++ b/core/model/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.32'
   testRuntimeOnly "net.bytebuddy:byte-buddy:${project.bytebuddyVersion}"
 
-  antlr "org.antlr:antlr4:4.9.2"
+  antlr "org.antlr:antlr4:4.11.1"
 }
 
 compileKotlin {


### PR DESCRIPTION
Resolves #1608

Currently seeing this issue:
```
ANTLR Tool version 4.9.2 used for code generation does not match the current runtime version 4.11.1
ANTLR Runtime version 4.9.2 used for parser compilation does not match the current runtime version 4.11.1
```

Bumping to the latest Antlr to resolve this issue