### PR TITLE
bump actions/setup-java to v3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,8 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: zulu
         java-version: 17
     - name: Cache Gradle packages
       uses: actions/cache@v2
@@ -44,8 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: ${{ matrix.jdk }}
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
The major version change from actions/setup-java v1 to v3 includes breaking changes due to an additional property (distribution) that is now required.

Multiple distributions exist, Zulu has the largest range of available versions available.

This makes #1613 obsolete.