### PR TITLE
Performance improvements around core/matchers

### DIFF
--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/util/CollectionUtils.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/util/CollectionUtils.kt
@@ -1,32 +1,11 @@
 package au.com.dius.pact.core.matchers.util
 
-fun tails(col: List<String>): List<List<String>> {
-  val result = mutableListOf<List<String>>()
-  var acc = col
-  while (acc.isNotEmpty()) {
-    result.add(acc)
-    acc = acc.drop(1)
-  }
-  result.add(acc)
-  return result
-}
-
-fun <A, B> corresponds(l1: List<A>, l2: List<B>, fn: (a: A, b: B) -> Boolean): Boolean {
-  return if (l1.size == l2.size) {
-    l1.zip(l2).all { fn(it.first, it.second) }
-  } else {
-    false
-  }
-}
+import java.util.Collections.nCopies
 
 fun <E> List<E>.padTo(size: Int, item: E): List<E> {
-  return if (size < this.size) {
-    this.dropLast(this.size - size)
-  } else {
-    val list = this.toMutableList()
-    for (i in this.size.until(size)) {
-      list.add(item)
-    }
-    return list
+  return when {
+    size < this.size -> subList(fromIndex = 0, toIndex = size)
+    size > this.size -> this + nCopies(size - this.size, item)
+    else -> this
   }
 }

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatchingContextSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatchingContextSpec.groovy
@@ -14,6 +14,7 @@ import au.com.dius.pact.core.model.matchingrules.MinMaxTypeMatcher
 import au.com.dius.pact.core.model.matchingrules.NullMatcher
 import au.com.dius.pact.core.model.matchingrules.RegexMatcher
 import au.com.dius.pact.core.model.matchingrules.TypeMatcher
+import au.com.dius.pact.core.model.matchingrules.ValuesMatcher
 import kotlin.Triple
 import spock.lang.Issue
 import spock.lang.Specification
@@ -289,6 +290,20 @@ class MatchingContextSpec extends Specification {
     where:
 
     category << [ 'header', 'query', 'metadata' ]
+  }
+
+  @Issue('#1347')
+  def 'values matcher must not cascade'() {
+    given:
+    def matchingRules = new MatchingRuleCategory('body')
+    matchingRules.addRule('$', ValuesMatcher.INSTANCE)
+    def context = new MatchingContext(matchingRules, true)
+
+    when:
+    def rules = context.selectBestMatcher(['$', 'id'])
+
+    then:
+    rules.rules == []
   }
 
   @Issue('#1367')

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/util/CollectionUtilsSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/util/CollectionUtilsSpec.groovy
@@ -6,19 +6,6 @@ import spock.lang.Unroll
 @SuppressWarnings('ClosureAsLastMethodParameter')
 class CollectionUtilsSpec extends Specification {
 
-  def 'tails test'() {
-    expect:
-    CollectionUtilsKt.tails(['a', 'b', 'c', 'd']) == [['a', 'b', 'c', 'd'], ['b', 'c', 'd'], ['c', 'd'], ['d'], []]
-    CollectionUtilsKt.tails(['something', '$']) == [['something', '$'], ['$'], []]
-  }
-
-  def 'corresponds test'() {
-    expect:
-    CollectionUtilsKt.<Integer, String>corresponds([1, 2, 3], ['1', '2', '3'], { a, b -> a == Integer.parseInt(b) })
-    !CollectionUtilsKt.<Integer, String>corresponds([1, 2, 4], ['1', '2', '3'], { a, b -> a == Integer.parseInt(b) })
-    !CollectionUtilsKt.<Integer, String>corresponds([1, 2, 3, 4], ['1', '2', '3'], { a, b -> a == Integer.parseInt(b) })
-  }
-
   @Unroll
   def 'padTo test'() {
     expect:

--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/matchingrules/MatchingRuleCategory.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/matchingrules/MatchingRuleCategory.kt
@@ -96,17 +96,6 @@ data class MatchingRuleCategory @JvmOverloads constructor(
   fun filter2(predicate: Predicate<Pair<String,MatchingRuleGroup>>) =
     copy(matchingRules = matchingRules.filter { predicate.test(it.key to it.value) }.toMutableMap())
 
-  fun maxBy(comparator: Comparator<String>): Pair<String, MatchingRuleGroup>? {
-    val max = matchingRules.entries.fold(matchingRules.entries.firstOrNull()) { acc, entry ->
-      if (acc != null && comparator.compare(acc.key, entry.key) >= 0) {
-        acc
-      } else {
-        entry
-      }
-    }
-    return max?.toPair()
-  }
-
   /**
    * Returns all the matching rules
    */


### PR DESCRIPTION
Hi,

please consider accepting these minor performance improvements around core/matchers.

Context: for a very large auto-generated Pact that I work with, these improvements reduce the verification time by half (~28 seconds -> ~13 seconds).

PS. The first commit adds a regression test for #1347.