### PR TITLE
feat: Auto DSL based on Kotlin object validating type of the item in the List

### DIFF
--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/DslJsonBodyBuilder.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/DslJsonBodyBuilder.kt
@@ -11,6 +11,9 @@ import kotlin.reflect.jvm.jvmErasure
 class DslJsonBodyBuilder {
     companion object {
         private val ISO_PATTERN = ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.pattern
+        private const val NUMBER_EXAMPLE = 1
+        private const val DATETIME_EXPRESSION_EXAMPLE = "now"
+        private const val BOOLEAN_EXAMPLE = true
     }
 
     /**
@@ -78,10 +81,10 @@ class DslJsonBodyBuilder {
             Long::class,
             Float::class,
             Number::class,
-            Double::class -> rootArray.numberType(1)
+            Double::class -> rootArray.numberType(NUMBER_EXAMPLE)
             String::class -> rootArray.stringType(listTypeCLass.simpleName)
-            Boolean::class -> rootArray.booleanType(true)
-            ZonedDateTime::class -> rootArray.datetimeExpression("now", ISO_PATTERN)
+            Boolean::class -> rootArray.booleanType(BOOLEAN_EXAMPLE)
+            ZonedDateTime::class -> rootArray.datetimeExpression(DATETIME_EXPRESSION_EXAMPLE, ISO_PATTERN)
             else -> {
                 rootArray.`object` { objDsl ->
                     objDsl.run {


### PR DESCRIPTION
When generating a DSL based on a Kotlin object, the item type of the list should be validated. 

Before this change, the code was creating one DSL only to check if the array exists in the parent object, without validating if the object type in the list is correct. 

So now, once the data contains a `List<Type>` in the constructor as a mandatory field, that has been used to create a type validation for that assuring the correct Type in the list is present. 

That said, if we have this object below:

```kotlin
data class ListObjectRequiredProperty(val properties: List<String>)
```

The DSL generated will be equivalent to:
```kotlin
            LambdaDsl.newJsonBody { it.array("properties") { arr ->
                arr.stringType("String")
            } }
```