### PR TITLE
Breaking Change - Support SpringBoot 3 & Java 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 Most of Pact-JVM is written in Kotlin and is built with Gradle. Tests are written using [Spock](https://spockframework.org/).
 
-Before you build, install java 11, `Gradle` and `Maven` (Maven is required to build the Maven plugin).
+Before you build, install java 17, `Gradle` and `Maven` (Maven is required to build the Maven plugin).
 
 #### To build the libraries:
 
@@ -21,7 +21,7 @@ You can publish pact-jvm to your local maven repo using:
     $ ./gradlew publishToMavenLocal
 
 If the build fails due to JVM memory issues, these are the settings reported to work:
->  set `org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8` in ~/.gradle/gradle.properties to fix metaspace problems with JDK 11
+>  set `org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8` in ~/.gradle/gradle.properties to fix metaspace problems with JDK 17
 
 To publish to a nexus repo:
 

--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
@@ -12,16 +12,16 @@ repositories {
     mavenCentral()
 }
 
-version = '4.4.5'
+version = '5.0.0'
 
 java {
-    targetCompatibility = '11'
-    sourceCompatibility = '11'
+    targetCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }
 

--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
@@ -15,13 +15,13 @@ repositories {
 version = '5.0.0'
 
 java {
-    targetCompatibility = '17'
-    sourceCompatibility = '17'
+    targetCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
 }
 

--- a/consumer/junit5/build.gradle
+++ b/consumer/junit5/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   testImplementation 'org.apache.groovy:groovy-json'
   testImplementation 'org.apache.groovy:groovy-xml'
   testImplementation 'org.apache.commons:commons-io:1.3.2'
-  testImplementation 'org.mockito:mockito-core:2.28.2'
+  testImplementation 'org.mockito:mockito-core:4.8.1'
   testImplementation 'org.hamcrest:hamcrest'
   testImplementation 'org.apache.httpcomponents.client5:httpclient5'
   testImplementation('io.rest-assured:rest-assured:5.2.0') {

--- a/provider/build.gradle
+++ b/provider/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   api project(':core:matchers')
   api project(':core:pactbroker')
   api 'org.apache.httpcomponents.client5:httpclient5'
-  api 'io.github.classgraph:classgraph:4.8.129'
+  api 'io.github.classgraph:classgraph:4.8.149'
 
   implementation 'commons-io:commons-io:2.11.0'
   implementation 'org.slf4j:slf4j-api'
@@ -30,7 +30,7 @@ dependencies {
   testImplementation 'org.spockframework:spock-core'
   testImplementation 'ch.qos.logback:logback-classic'
   testImplementation 'org.apache.groovy:groovy-json'
-  testImplementation 'org.mockito:mockito-core:2.28.2'
+  testImplementation 'org.mockito:mockito-core:4.8.1'
   testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
   testImplementation 'junit:junit'
   testImplementation 'io.dropwizard:dropwizard-testing:2.1.3'

--- a/provider/gradle/build.gradle
+++ b/provider/gradle/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation 'io.github.microutils:kotlin-logging-jvm:2.1.23'
 
   testImplementation 'junit:junit'
-  testImplementation 'org.mockito:mockito-core:2.28.2'
+  testImplementation 'org.mockito:mockito-core:4.8.1'
 
   // This needs to match the version of Groovy provided by Gradle
   testImplementation('org.spockframework:spock-core:2.3-groovy-3.0') {

--- a/provider/junit5spring/build.gradle
+++ b/provider/junit5spring/build.gradle
@@ -12,12 +12,13 @@ dependencies {
   implementation 'org.springframework:spring-test:6.0.4'
   implementation 'org.springframework:spring-web:6.0.4'
   implementation 'org.springframework:spring-webflux:6.0.4'
+  compileOnly 'jakarta.servlet:jakarta.servlet-api:6.0.0'
   implementation 'javax.servlet:javax.servlet-api:3.1.0'
   implementation 'org.hamcrest:hamcrest:2.2'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'javax.mail:mail:1.5.0-b01'
 
-  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.0'
-  testImplementation 'org.springframework.boot:spring-boot-starter-web:3.0.0'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.2'
+  testImplementation 'org.springframework.boot:spring-boot-starter-web:3.0.2'
   testImplementation 'org.apache.groovy:groovy'
 }

--- a/provider/junit5spring/build.gradle
+++ b/provider/junit5spring/build.gradle
@@ -8,16 +8,16 @@ group = 'au.com.dius.pact.provider'
 dependencies {
   api project(':provider:junit5')
 
-  implementation 'org.springframework:spring-context:5.3.20'
-  implementation 'org.springframework:spring-test:5.3.20'
-  implementation 'org.springframework:spring-web:5.3.20'
-  implementation 'org.springframework:spring-webflux:5.3.20'
+  implementation 'org.springframework:spring-context:6.0.4'
+  implementation 'org.springframework:spring-test:6.0.4'
+  implementation 'org.springframework:spring-web:6.0.4'
+  implementation 'org.springframework:spring-webflux:6.0.4'
   implementation 'javax.servlet:javax.servlet-api:3.1.0'
   implementation 'org.hamcrest:hamcrest:2.2'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'javax.mail:mail:1.5.0-b01'
 
-  testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.14'
-  testImplementation 'org.springframework.boot:spring-boot-starter-web:2.5.14'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.0'
+  testImplementation 'org.springframework.boot:spring-boot-starter-web:3.0.0'
   testImplementation 'org.apache.groovy:groovy'
 }

--- a/provider/junit5spring/build.gradle
+++ b/provider/junit5spring/build.gradle
@@ -1,6 +1,16 @@
 plugins {
   id 'au.com.dius.pact.kotlin-library-conventions'
 }
+java {
+  targetCompatibility = '17'
+  sourceCompatibility = '17'
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+}
 
 description = 'Pact-JVM - Provider Spring/JUnit5 Support'
 group = 'au.com.dius.pact.provider'

--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
@@ -12,6 +12,7 @@ import au.com.dius.pact.provider.IProviderVerifier
 import au.com.dius.pact.provider.ProviderInfo
 import au.com.dius.pact.provider.ProviderResponse
 import au.com.dius.pact.provider.junit5.TestTarget
+import jakarta.servlet.http.Cookie
 import mu.KLogging
 import org.apache.commons.lang3.StringUtils
 import org.hamcrest.core.IsAnything
@@ -37,7 +38,6 @@ import java.net.URI
 import javax.mail.internet.ContentDisposition
 import javax.mail.internet.MimeMultipart
 import javax.mail.util.ByteArrayDataSource
-import javax.servlet.http.Cookie
 
 /**
  * Test target for tests using Spring MockMvc.

--- a/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/FooControllerTest.java
+++ b/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/FooControllerTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
 /*
   This is a test for issue https://github.com/pact-foundation/pact-jvm/issues/1242

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -1,6 +1,16 @@
 plugins {
   id 'au.com.dius.pact.kotlin-library-conventions'
 }
+java {
+  targetCompatibility = '17'
+  sourceCompatibility = '17'
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+}
 
 description = 'Pact-JVM - Pact Provider Spring/JUnit runner'
 group = 'au.com.dius.pact.provider'

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   implementation group: 'org.springframework', name: 'spring-test', version: '6.0.4'
   implementation group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.13.4'
+  compileOnly 'jakarta.servlet:jakarta.servlet-api:6.0.0'
   runtimeOnly group: 'org.synchronoss.cloud', name: 'nio-multipart-parser', version: '1.1.0'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'javax.mail:mail:1.5.0-b01'

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -9,10 +9,10 @@ dependencies {
   api project(':provider:junit')
 
   implementation 'org.apache.groovy:groovy'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.5.14'
-  implementation group: 'org.springframework', name: 'spring-webmvc', version: '5.3.19'
-  implementation group: 'org.springframework', name: 'spring-webflux', version: '5.3.19'
-  implementation group: 'org.springframework', name: 'spring-test', version: '5.3.19'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '3.0.0'
+  implementation group: 'org.springframework', name: 'spring-webmvc', version: '6.0.4'
+  implementation group: 'org.springframework', name: 'spring-webflux', version: '6.0.4'
+  implementation group: 'org.springframework', name: 'spring-test', version: '6.0.4'
   implementation group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.13.4'
   runtimeOnly group: 'org.synchronoss.cloud', name: 'nio-multipart-parser', version: '1.1.0'
@@ -20,7 +20,7 @@ dependencies {
   implementation 'javax.mail:mail:1.5.0-b01'
   implementation 'org.apache.commons:commons-collections4'
 
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.5.14'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.0.0'
   testImplementation 'org.apache.groovy:groovy'
   testRuntimeOnly 'net.bytebuddy:byte-buddy'
 }

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   api project(':provider:junit')
 
   implementation 'org.apache.groovy:groovy'
-  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '3.0.0'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '3.0.2'
   implementation group: 'org.springframework', name: 'spring-webmvc', version: '6.0.4'
   implementation group: 'org.springframework', name: 'spring-webflux', version: '6.0.4'
   implementation group: 'org.springframework', name: 'spring-test', version: '6.0.4'
@@ -20,7 +20,7 @@ dependencies {
   implementation 'javax.mail:mail:1.5.0-b01'
   implementation 'org.apache.commons:commons-collections4'
 
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.0.0'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '3.0.2'
   testImplementation 'org.apache.groovy:groovy'
   testRuntimeOnly 'net.bytebuddy:byte-buddy'
 }

--- a/provider/spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderStates.java
+++ b/provider/spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderStates.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 public class BooksPactProviderStates {

--- a/provider/spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java
+++ b/provider/spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java
@@ -1,7 +1,7 @@
 package au.com.dius.pact.provider.spring;
 
-import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junit.RestPactRunner;
+import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.State;
 import au.com.dius.pact.provider.junitsupport.TargetRequestFilter;
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(RestPactRunner.class)


### PR DESCRIPTION
Hello,

Here is a PR to support Spring Boot 3 on Pact JVM. Since SpringBoot 3 is compiling with JDK 17, I had to pass to Java 17 in the project as well.

I have been able to test from another project  and it is working with Spring Boot 3 and this local version `provider:junit5spring:5.0.0`.

This PR should fix #1660 

Feel free to review and provide your suggestions.

Thanks,
Ludo