### PR TITLE
fix merging message pacts - old messages taking precedence

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/messaging/MessagePact.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/messaging/MessagePact.kt
@@ -70,7 +70,7 @@ class MessagePact @JvmOverloads constructor (
 
   override fun mergeInteractions(interactions: List<Interaction>): Pact {
     interactions as List<Message>
-    messages = (messages + interactions).distinctBy { it.uniqueKey() }.toMutableList()
+    messages = (interactions + messages).distinctBy { it.uniqueKey() }.toMutableList()
     sortInteractions()
     return this
   }

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/messaging/MessagePactSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/messaging/MessagePactSpec.groovy
@@ -85,4 +85,31 @@ class MessagePactSpec extends Specification {
     pact2 = new MessagePact(provider, consumer, [ message, message2 ])
   }
 
+  def 'merge message pact'() {
+    when:
+    pact.mergeInteractions(pact2.interactions)
+
+    then:
+    pact.interactions == [ newMessage1, message2 ]
+
+    where:
+    newMessage1 = new Message('message', [], OptionalBody.body('0 9 8 7'.bytes))
+    message2 = new Message('message2', [], OptionalBody.body('A B C'.bytes))
+    pact = new MessagePact(provider, consumer, [ message ])
+    pact2 = new MessagePact(provider, consumer, [ newMessage1, message2 ])
+  }
+
+
+  def 'merge message pact - same'() {
+    when:
+    pact.mergeInteractions(pact2.interactions)
+
+    then:
+    pact.interactions == [ message ]
+
+    where:
+    pact = new MessagePact(provider, consumer, [ message ])
+    pact2 = new MessagePact(provider, consumer, [ message ])
+  }
+
 }


### PR DESCRIPTION
So when we change our pact to contain new field, for example, we run the consumer test and it doesnt update the pact file because it thinks that the message is the same.
The bug being is that we adding 2 collections - `old + new` - and then `distinctBy` - in this case old duplicates will take precedence 