### PR TITLE
Use shorthand annotation instead of @ExtendWith

### DIFF
--- a/consumer/junit5/README.md
+++ b/consumer/junit5/README.md
@@ -15,9 +15,15 @@ The library is available on maven central using:
 
 ### 1. Add the Pact consumer test extension to the test class.
 
-To write Pact consumer tests with JUnit 5, you need to add `@ExtendWith(PactConsumerTestExt)` to your test class. This
+To write Pact consumer tests with JUnit 5, you need to add `@PactConsumerTest` to your test class. This
 replaces the `PactRunner` used for JUnit 4 tests. The rest of the test follows a similar pattern as for JUnit 4 tests.
 
+```java
+@PactConsumerTest
+class ExampleJavaConsumerPactTest {
+```
+
+Alternatively, you can explicitly declare the JUnit extension.
 ```java
 @ExtendWith(PactConsumerTestExt.class)
 class ExampleJavaConsumerPactTest {
@@ -55,7 +61,7 @@ allows you to set the hostname to bind to (default is `localhost`) and the port 
 can also set the Pact specification version to use (default is V3).
 
 ```java
-@ExtendWith(PactConsumerTestExt.class)
+@PactConsumerTest
 @PactTestFor(providerName = "ArticlesProvider")
 public class ExampleJavaConsumerPactTest {
 ```
@@ -303,7 +309,7 @@ setup the interaction.
 For example, if we use the CSV plugin from the plugins project, our test would look like:
 
 ```java
-@ExtendWith(PactConsumerTestExt.class)
+@PactConsumerTest
 class CsvClientTest {
   /**
    * Setup an interaction that makes a request for a CSV report 

--- a/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTest.kt
+++ b/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTest.kt
@@ -1,0 +1,15 @@
+package au.com.dius.pact.consumer.junit5
+
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.extension.ExtendWith
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+
+// Shorthand for @ExtendWith(PactConsumerTestExt::class)
+@ExtendWith(PactConsumerTestExt::class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(
+    AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS
+)
+annotation class PactConsumerTest

--- a/consumer/junit5/src/test/java/au/com/dius/pact/consumer/junit5/PactConsumerAnnotationTest.java
+++ b/consumer/junit5/src/test/java/au/com/dius/pact/consumer/junit5/PactConsumerAnnotationTest.java
@@ -1,0 +1,140 @@
+package au.com.dius.pact.consumer.junit5;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.annotations.PactDirectory;
+import groovy.json.JsonOutput;
+import org.apache.hc.client5.http.fluent.Request;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@PactConsumerTest
+@PactTestFor(providerName = "multitest_provider", pactVersion = PactSpecVersion.V3)
+@PactDirectory("build/pacts/multi-test")
+class PactConsumerAnnotationTest {
+
+  static final String EXPECTED_USER_ID = "abcdefghijklmnop";
+  static final String CONTENT_TYPE = "Content-Type";
+  static final String APPLICATION_JSON = "application/json.*";
+  static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; charset=UTF-8";
+  static final String SOME_SERVICE_USER = "/some-service/user/";
+
+  static Map<String, String> user() {
+    return Map.of("username", "bbarke",
+      "password", "123456",
+      "firstname", "Brent",
+      "lastname", "Barker",
+      "boolean", "true"
+    );
+  }
+
+  @Nested
+  class Test1 {
+
+    @Pact(provider = "multitest_provider", consumer = "browser_consumer")
+    RequestResponsePact createFragment1(PactDslWithProvider builder) {
+      return builder
+        .given("An env")
+        .uponReceiving("a new user")
+          .path("/some-service/users")
+          .method("POST")
+          .body(JsonOutput.toJson(user()))
+          .matchHeader(CONTENT_TYPE, APPLICATION_JSON, APPLICATION_JSON_CHARSET_UTF_8)
+        .willRespondWith()
+          .status(201)
+          .matchHeader("Location", "http(s)?://\\w+:\\d+//some-service/user/\\w{36}$",
+            "http://localhost:8080/some-service/user/" + EXPECTED_USER_ID)
+        .given("An automation user with id: " + EXPECTED_USER_ID)
+        .uponReceiving("existing user lookup")
+          .path(SOME_SERVICE_USER + EXPECTED_USER_ID)
+          .method("GET")
+        .willRespondWith()
+          .status(200)
+          .matchHeader("Content-Type", APPLICATION_JSON, APPLICATION_JSON_CHARSET_UTF_8)
+          .body(JsonOutput.toJson(user()))
+        .toPact();
+    }
+
+    @Test
+    void runTest1(MockServer mockServer) throws IOException {
+      ClassicHttpResponse postResponse = (ClassicHttpResponse) Request.post(mockServer.getUrl() + "/some-service/users")
+        .bodyString(JsonOutput.toJson(user()), ContentType.APPLICATION_JSON)
+        .execute().returnResponse();
+
+      assertThat(postResponse.getCode(), is(equalTo(201)));
+      assertThat(postResponse.getFirstHeader("Location").getValue(),
+        is(equalTo("http://localhost:8080/some-service/user/abcdefghijklmnop")));
+
+
+      ClassicHttpResponse httpResponse = (ClassicHttpResponse) Request.get(mockServer.getUrl() + SOME_SERVICE_USER + EXPECTED_USER_ID)
+        .execute().returnResponse();
+      assertThat(httpResponse.getCode(), is(equalTo(200)));
+    }
+  }
+
+  @Nested
+  class Test2 {
+    @Pact(provider= "multitest_provider", consumer= "test_consumer")
+    RequestResponsePact createFragment2(PactDslWithProvider builder) {
+      return builder
+        .given("test state")
+        .uponReceiving("A request with double precision number")
+          .path("/numbertest")
+          .method("PUT")
+          .body("{\"name\": \"harry\",\"data\": 1234.0 }", "application/json")
+        .willRespondWith()
+          .status(200)
+          .body("{\"responsetest\": true, \"name\": \"harry\",\"data\": 1234.0 }", "application/json")
+        .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "createFragment2")
+    void runTest2(MockServer mockServer) throws IOException {
+      assert Request.put(mockServer.getUrl() + "/numbertest")
+        .addHeader("Accept", "application/json")
+        .bodyString("{\"name\": \"harry\",\"data\": 1234.0 }", ContentType.APPLICATION_JSON)
+        .execute().returnContent().asString().equals("{\"responsetest\": true, \"name\": \"harry\",\"data\": 1234.0 }");
+    }
+
+    @Pact(provider = "multitest_provider", consumer = "test_consumer")
+    RequestResponsePact getUsersFragment(PactDslWithProvider builder) {
+      DslPart body = PactDslJsonArray.arrayMaxLike(5)
+        .uuid("id", "7b374cc6-d644-11eb-a613-4ffac1365f0e")
+        .stringType("userName", "Bob")
+        .stringType("email", "bob@bobville")
+        .closeObject();
+      return builder
+        .given("a user with an id named 'user' exists")
+        .uponReceiving("get all users for max")
+          .path("/idm/user")
+          .method("GET")
+        .willRespondWith()
+          .status(200)
+          .body(body)
+        .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getUsersFragment")
+    void runTest3(MockServer mockServer) throws IOException {
+      assertThat(Request.get(mockServer.getUrl() + "/idm/user").execute().returnContent().asString(),
+        is("[{\"email\":\"bob@bobville\",\"id\":\"7b374cc6-d644-11eb-a613-4ffac1365f0e\",\"userName\":\"Bob\"}]"));
+    }
+  }
+}


### PR DESCRIPTION
What do folks think of this? 

Instead of 

```java
@ExtendWith(PactConsumerTestExt.class)
class ExampleJavaConsumerPactTest {
```
... a shorter form:

```java
@PactConsumerTest
class ExampleJavaConsumerPactTest {
```

It has the disadvantage that 
- Now there's two ways to do things
- It's less obvious what's happening under the covers, to people who know JUnit 5
- If JUnit 6 (say) introduced a totally different API, the `@PactConsumerTest` annotation would have to change, even though on the surface it looks like it should be independent of JUnit versions 
- There's a bit of overlap with the meaning of `@PactTestFor`. I wondered about just adding the `@ExtendWith` to `@PactTestFor` but I don't think it works since it can also be used on methods

It has the advantage that
- It's tidier and easier to read, with less typing
- It works more easily with tab completion

I've just done it for the consumer side, but if the community thinks it's a good idea, we'd want it for both consumer and provider.