### PR TITLE
Allow to set the port via an expression.

### DIFF
--- a/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/ProviderInfo.kt
+++ b/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/ProviderInfo.kt
@@ -115,7 +115,8 @@ data class ProviderInfo @JvmOverloads constructor(
         ProviderType.UNSPECIFIED -> null
         else -> annotation.providerType
       }
-      return ProviderInfo(providerName, annotation.hostInterface, annotation.port, pactVersion, providerType,
+      val port = ExpressionParser().parseExpression(annotation.port, DataType.STRING)?.toString() ?: annotation.port
+      return ProviderInfo(providerName, annotation.hostInterface, port, pactVersion, providerType,
         annotation.https, annotation.mockServerImplementation, annotation.keyStorePath, annotation.keyStoreAlias,
         annotation.keyStorePassword, annotation.privateKeyPassword)
     }

--- a/consumer/junit5/src/test/java/au/com/dius/pact/consumer/junit5/PactTestForPortTest.java
+++ b/consumer/junit5/src/test/java/au/com/dius/pact/consumer/junit5/PactTestForPortTest.java
@@ -1,0 +1,82 @@
+package au.com.dius.pact.consumer.junit5;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.hc.client5.http.fluent.Request;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author Christopher Holomek (christopher.holomek@bmw.de)
+ * @since 12.05.23
+ */
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "ArticlesProvider", pactVersion = PactSpecVersion.V3)
+public class PactTestForPortTest {
+
+    private String response;
+    final private String EXPECTED_RESPONSE = "expected";
+
+    private Map<String, String> headers = MapUtils.putAll(new HashMap<>(), new String[] {
+            "Content-Type", "text/plain"
+    });
+
+    @BeforeEach
+    void beforeEach() {
+        System.setProperty("pact.test.port", "1234");
+        response = EXPECTED_RESPONSE;
+    }
+
+    @AfterEach
+    void afterEach() {
+        System.clearProperty("pact.test.port");
+    }
+
+    @Pact(consumer = "Consumer")
+    public RequestResponsePact pactExecutedAfterBeforeEach(PactDslWithProvider builder) {
+        return builder
+                .given("provider state")
+                .uponReceiving("request")
+                .path("/")
+                .method("GET")
+                .willRespondWith()
+                .headers(headers)
+                .status(200)
+                .body(response)
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "pactExecutedAfterBeforeEach")
+    @MockServerConfig(port = "${pact.test.port}")
+    void testPactExecutedAfterBeforeEach(MockServer mockServer) throws IOException {
+        ClassicHttpResponse httpResponse = (ClassicHttpResponse) Request.get(mockServer.getUrl() + "/").execute().returnResponse();
+        assertThat(IOUtils.toString(httpResponse.getEntity().getContent()),
+                is(equalTo(EXPECTED_RESPONSE)));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "pactExecutedAfterBeforeEach", port = "${pact.test.port}")
+    void testPactExecutedAfterBeforeEachClassic(MockServer mockServer) throws IOException {
+        ClassicHttpResponse httpResponse = (ClassicHttpResponse) Request.get(mockServer.getUrl() + "/").execute().returnResponse();
+        assertThat(IOUtils.toString(httpResponse.getEntity().getContent()),
+                is(equalTo(EXPECTED_RESPONSE)));
+    }
+}

--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/model/MockProviderConfig.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/model/MockProviderConfig.kt
@@ -2,6 +2,8 @@ package au.com.dius.pact.consumer.model
 
 import au.com.dius.pact.consumer.junit.MockServerConfig
 import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.support.expressions.DataType
+import au.com.dius.pact.core.support.expressions.ExpressionParser
 import io.ktor.util.network.hostname
 import java.net.InetSocketAddress
 import java.util.Optional
@@ -122,9 +124,10 @@ open class MockProviderConfig @JvmOverloads constructor (
     fun fromMockServerAnnotation(config: Optional<MockServerConfig>): MockProviderConfig? {
       return if (config.isPresent) {
         val annotation = config.get()
+        val port = ExpressionParser().parseExpression(annotation.port, DataType.STRING)?.toString() ?: annotation.port
         MockProviderConfig(
           annotation.hostInterface.ifEmpty { LOCALHOST },
-          if (annotation.port.isEmpty()) 0 else annotation.port.toInt(),
+          if (port.isEmpty()) 0 else port.toInt(),
           PactSpecVersion.UNSPECIFIED,
           if (annotation.tls) "https" else HTTP,
           annotation.implementation,


### PR DESCRIPTION
At the moment it is not possible to define the used port via an expression. I am aware that there is the 0 = random port, but we need this because the port needs to be set in a process, which is running way before the random port of pact is calculated. So for us we have a kind of "dirty" workaround, which determines a random port, sets this to the process I mentioned and then applies this port to pact. It would be great to set the port via a system property.

What do you think?

Br,
Chris