### PR TITLE
use valid module name in manifest

### DIFF
--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-library-conventions.gradle
@@ -41,7 +41,7 @@ jar {
           'Specification-Vendor': project.group,
           'Specification-Title': project.name,
           'Specification-Version': archiveVersion,
-          'Automatic-Module-Name': project.group + "." + project.name.replaceAll('-', '_')
+          'Automatic-Module-Name': (project.group + "." + project.name).replaceAll('-', '_')
     }
 }
 


### PR DESCRIPTION
commit https://github.com/pact-foundation/pact-jvm/commit/0338f438c3d4fc82c49e6c88c4833cb44238af30 (see settings.gradle) broke the previouse work around