### PR TITLE
fix: generate providerStates as in V3 when PactVersion is UNSPECIFIED

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactSpecVersion.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactSpecVersion.kt
@@ -5,7 +5,7 @@ package au.com.dius.pact.core.model
  */
 @Suppress("EnumNaming")
 enum class PactSpecVersion {
-  UNSPECIFIED, V1, V1_1, V2, V3, V4;
+  V1, V1_1, V2, V3, UNSPECIFIED, V4;
 
   fun versionString(): String {
     return when (this) {

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/RequestResponseInteractionSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/RequestResponseInteractionSpec.groovy
@@ -40,6 +40,25 @@ class RequestResponseInteractionSpec extends Specification {
 
   }
 
+  def 'creates a V3 map format if UNSPECIFIED spec'() {
+    when:
+    def map = interaction.toMap(PactSpecVersion.UNSPECIFIED)
+
+    then:
+    map == [
+      description: 'test interaction',
+      request: [method: 'GET', path: '/', generators: [header: [a: [type: 'RandomString', size: 4]]]],
+      response: [status: 200, generators: [header: [a: [type: 'RandomString', size: 4]]]],
+      providerStates: [
+        [name: 'state one'],
+        [name: 'state two', params: [
+          value: 'one', other: '2']
+        ]
+      ]
+    ]
+
+  }
+
   def 'creates a V2 map format if not V3 spec'() {
     when:
     def map = interaction.toMap(PactSpecVersion.V1_1)


### PR DESCRIPTION
fix https://github.com/pact-foundation/pact-jvm/issues/1705

I chose the path of least modifications.
A more definitive solution might be to change the default pactVersion to V3 in `PactSpectVersion` instead of `UNSPECIFIED`, but that would change the philosophy of how it is done.