### PR TITLE
Issue 1758 - Add latest flag when comparing to the main branch 

### DIFF
--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/PactBrokerClient.kt
@@ -1155,6 +1155,7 @@ open class PactBrokerClient(
 
         if (to.mainBranch == true) {
           params.add("mainBranch" to "true")
+          params.add("latest" to "true")
         } else if (to.environment.isNullOrEmpty() && to.tag.isNullOrEmpty()) {
           params.add("latest" to "true")
         }

--- a/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/PactBrokerClientSpec.groovy
+++ b/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/PactBrokerClientSpec.groovy
@@ -707,9 +707,9 @@ class PactBrokerClientSpec extends Specification {
     'Test'       | ''                 | new Latest.UseLatest(true)         | new To(null, 'env1', false)   | []                                                                 || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env1'
     'Test'       | ''                 | new Latest.UseLatest(true)         | new To('tag1', 'env1', false) | []                                                                 || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env1&latest=true&tag=tag1'
     'Test'       | ''                 | new Latest.UseLatest(true)         | new To(null, 'env 1', false)  | []                                                                 || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env+1'
-    'Test'       | ''                 | new Latest.UseLatest(true)         | new To(null, 'env1', true)   | []                                                                  || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env1&mainBranch=true'
-    'Test'       | ''                 | new Latest.UseLatest(true)         | new To('tag1', 'env1', true) | []                                                                  || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env1&latest=true&tag=tag1&mainBranch=true'
-    'Test'       | ''                 | new Latest.UseLatest(true)         | new To(null, 'env 1', true)  | []                                                                  || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env+1&mainBranch=true'
+    'Test'       | ''                 | new Latest.UseLatest(true)         | new To(null, 'env1', true)   | []                                                                  || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env1&mainBranch=true&latest=true'
+    'Test'       | ''                 | new Latest.UseLatest(true)         | new To('tag1', 'env1', true) | []                                                                  || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env1&latest=true&tag=tag1&mainBranch=true&latest=true'
+    'Test'       | ''                 | new Latest.UseLatest(true)         | new To(null, 'env 1', true)  | []                                                                  || 'q[][pacticipant]=Test&latestby=cvp&q[][latest]=true&environment=env+1&mainBranch=true&latest=true'
   }
 
   @Issue('#1511')


### PR DESCRIPTION
Currently all versions of the main branch are compared instead of just the latest. The latest query parameter needs to be added to the parameters to make sure only the latest is checked.

fixes #1758