### PR TITLE
Update README.md

### DIFF
--- a/provider/junit5spring/README.md
+++ b/provider/junit5spring/README.md
@@ -83,7 +83,7 @@ For example:
 class MockMvcTestTargetStandaloneMockMvcTestJava {
 
     @TestTemplate
-    @ExtendWith(PactVerificationSpringProvider.class)
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
     void pactVerificationTestTemplate(PactVerificationContext context) {
         context.verifyInteraction();
     }


### PR DESCRIPTION
The explanation already says that you cannot use `PactVerificationSpringProvider` without `@WebMvcTest` annotation. Therefore it falls into `PactVerificationInvocationContextProvider` extension.