### PR TITLE
Make plugindriver version consistent

### DIFF
--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
@@ -31,7 +31,7 @@ dependencies {
         api 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
         api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.2.1'
         api 'org.json:json:20240205'
-        api 'io.pact.plugin.driver:core:0.5.1'
+        api 'io.pact.plugin.driver:core:0.5.1' // remember also to update implementation
         api 'org.apache.tika:tika-core:2.9.1'
         api 'io.github.oshai:kotlin-logging-jvm:5.1.4'
 
@@ -50,7 +50,7 @@ dependencies {
         implementation 'org.apache.groovy:groovy:4.0.18'
         implementation 'org.apache.groovy:groovy-json:4.0.18'
         implementation 'org.apache.groovy:groovy-xml:4.0.18'
-        implementation 'io.pact.plugin.driver:core:0.4.2'
+        implementation 'io.pact.plugin.driver:core:0.5.1'  //remember to also update under api
         implementation 'commons-codec:commons-codec:1.15'
         implementation 'io.github.oshai:kotlin-logging-jvm:5.1.4'
 


### PR DESCRIPTION
In our project we have the following config:

```
configurations {
    all {
      resolutionStrategy {
        failOnVersionConflict()
        force(dependencyVersions)
      }
    }
  }

```

With that we see that with the update to pact 4.6.14 there is a new version conflict of the plugin driver

Looking in the project I can see, that there is `io.pact.plugin.driver:core:0.5.1` and `io.pact.plugin.driver:core:0.4.2` defined, depending if you use `api` or `implementation`.

I aligned the version now. In our projects we have either reminder comments or we have variables.
I here thought the least intrusive way is a comment to hopefully remind people to update the version in 2 places in future.

