### PR TITLE
Update httpclient5

### DIFF
--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
@@ -28,8 +28,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 dependencies {
     constraints {
         // Define dependency versions as constraints
-        api 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
-        api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.2.1'
+        api 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+        api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3.1'
         api 'org.json:json:20240205'
         api 'io.pact.plugin.driver:core:0.5.1'
         api 'org.apache.tika:tika-core:2.9.1'


### PR DESCRIPTION
with version 4.6.14 we see that there is a dependency conflict coming in from the driver using org.apache.httpcomponents.client5:httpclient5(-fluent):5.3.1 and here it is 5.2.1

to get it consistent we can simply update the version here as well