### PR TITLE
Support using other JUnit @Disabled.. annotations

### DIFF
--- a/consumer/junit5/src/test/groovy/au/com/dius/pact/consumer/junit5/MultiTest.groovy
+++ b/consumer/junit5/src/test/groovy/au/com/dius/pact/consumer/junit5/MultiTest.groovy
@@ -13,6 +13,7 @@ import org.apache.hc.client5.http.fluent.Request
 import org.apache.hc.core5.http.ContentType
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.extension.ExtendWith
 
 @SuppressWarnings(['PublicInstanceField', 'JUnitPublicNonTestMethod', 'FactoryMethodName'])
@@ -152,5 +153,21 @@ class MultiTest {
       .willRespondWith()
       .status(404)
       .toPact()
+  }
+
+  @Pact(provider = 'multitest_provider', consumer = 'test_consumer')
+  @DisabledIf('shouldBeDisabled')
+  RequestResponsePact getAnotherUsersFragment3(PactDslWithProvider builder) {
+    builder
+      .uponReceiving('get all users')
+      .path('/idm/user')
+      .method('GET')
+      .willRespondWith()
+      .status(404)
+      .toPact()
+  }
+
+  boolean shouldBeDisabled() {
+    true
   }
 }


### PR DESCRIPTION
Support for more than just JUnit's `@Disabled` annotation...

```kotlin
org.junit.jupiter.api.condition.DisabledForJreRange
org.junit.jupiter.api.condition.DisabledIf
org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
org.junit.jupiter.api.condition.DisabledIfEnvironmentVariables
org.junit.jupiter.api.condition.DisabledIfSystemProperties
org.junit.jupiter.api.condition.DisabledIfSystemProperty
org.junit.jupiter.api.condition.DisabledInNativeImage
org.junit.jupiter.api.condition.DisabledOnJre
org.junit.jupiter.api.condition.DisabledOnOs
```