### PR TITLE
fix: Ensure provider state is injected when verifying sync message pacts

### DIFF
--- a/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactVerificationContext.kt
+++ b/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactVerificationContext.kt
@@ -168,6 +168,17 @@ data class PactVerificationContext @JvmOverloads constructor(
           client, request, context + ("userConfig" to targetForInteraction.userConfig)))
       }
       else -> {
+        when (interaction) {
+          is V4Interaction.SynchronousMessages -> {
+            interaction.request = DefaultResponseGenerator.generateContents(
+              interaction.request, context,
+              GeneratorTestMode.Provider,
+              pact.asV4Pact().get()?.pluginData() ?: emptyList(),
+              interaction.pluginConfiguration.toMap(),
+              true
+            )
+          }
+        }
         return listOf(verifier!!.verifyResponseByInvokingProviderMethods(providerInfo, consumer, interaction,
           interaction.description, mutableMapOf(), consumer.pending, pluginConfigForInteraction(pact, interaction)))
       }

--- a/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/SyncMessageWithProviderStateTest.java
+++ b/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/SyncMessageWithProviderStateTest.java
@@ -1,0 +1,55 @@
+package au.com.dius.pact.provider.junit5;
+
+import au.com.dius.pact.core.model.v4.MessageContents;
+import au.com.dius.pact.core.support.json.JsonParser;
+import au.com.dius.pact.provider.MessageAndMetadata;
+import au.com.dius.pact.provider.PactVerifyProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@Provider("SyncMessageProviderStateService")
+@PactFolder("pacts")
+public class SyncMessageWithProviderStateTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncMessageWithProviderStateTest.class);
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void testTemplate(PactVerificationContext context) {
+      context.verifyInteraction();
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        context.setTarget(new MessageTestTarget());
+    }
+
+    @State("the provider injects a 'stateValue'")
+    public Map<String, Object> defaultState() {
+      return Map.of(
+              "stateValue", "PROVIDER_STATE_VALUE"
+      );
+    }
+
+    @PactVerifyProvider("State has been inserted in request message")
+    public MessageAndMetadata stateHasBeenInserted(MessageContents messageContents) {
+        var json = JsonParser.parseString(messageContents.getContents().valueAsString());
+        var value = json.asObject().get("state").asString();
+
+        // This is what this test is truly asserting
+        assertThat(value, is("PROVIDER_STATE_VALUE"));
+
+        return new MessageAndMetadata(
+                "{\"state\": \"PROVIDER_STATE_VALUE\"}".getBytes(), Map.of());
+    }
+}

--- a/provider/junit5/src/test/resources/pacts/SyncMessageConsumer-SyncMessageProviderStateService.json
+++ b/provider/junit5/src/test/resources/pacts/SyncMessageConsumer-SyncMessageProviderStateService.json
@@ -1,0 +1,97 @@
+{
+  "consumer": {
+    "name": "SyncMessageConsumer"
+  },
+  "interactions": [
+    {
+      "description": "State has been inserted in request message",
+      "key": "",
+      "pending": false,
+      "providerStates": [
+        {
+          "name": "the provider injects a 'stateValue'"
+        }
+      ],
+      "request": {
+        "contents": {
+          "content": {
+            "state": "ExampleValue"
+          },
+          "contentType": "application/json",
+          "encoded": false
+        },
+        "generators": {
+          "body": {
+            "$.state": {
+              "dataType": "STRING",
+              "expression": "stateValue",
+              "type": "ProviderState"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.state": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "metadata": {
+          "contentType": "application/json"
+        }
+      },
+      "response": [
+        {
+          "contents": {
+            "content": {
+              "state": "ExampleValue"
+            },
+            "contentType": "application/json",
+            "encoded": false
+          },
+          "generators": {
+            "body": {
+              "$.state": {
+                "dataType": "STRING",
+                "expression": "stateValue",
+                "type": "ProviderState"
+              }
+            }
+          },
+          "matchingRules": {
+            "body": {
+              "$.state": {
+                "combine": "AND",
+                "matchers": [
+                  {
+                    "match": "type"
+                  }
+                ]
+              }
+            }
+          },
+          "metadata": {
+            "contentType": "application/json"
+          }
+        }
+      ],
+      "type": "Synchronous/Messages"
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.6.17"
+    },
+    "pactSpecification": {
+      "version": "4.0"
+    }
+  },
+  "provider": {
+    "name": "SyncMessageProviderStateService"
+  }
+}

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
@@ -1451,6 +1451,7 @@ open class ProviderVerifier @JvmOverloads constructor (
           m.invoke(instance)
         }
       } catch (e: Throwable) {
+        logger.warn(e) { "Failed to invoke provider method '${m.name}'" }
         throw RuntimeException("Failed to invoke provider method '${m.name}'", e)
       }
     }


### PR DESCRIPTION
When working with synchronous message pact tests we were running into an issue where we noticed that the provider state was not being injected in the request messages.

I did some investigation and it seems that this was just not done for sync message pacts.
This PR adds a change to make sure that the generated request is included in the interaction.