### PR TITLE
Update classgraph to work around compatibility issue

### DIFF
--- a/provider/build.gradle
+++ b/provider/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   api project(':core:matchers')
   api project(':core:pactbroker')
   api 'org.apache.httpcomponents.client5:httpclient5'
-  api 'io.github.classgraph:classgraph:4.8.129'
+  api 'io.github.classgraph:classgraph:4.8.178'
   api('io.pact.plugin.driver:core') {
     exclude group: 'au.com.dius.pact.core'
   }


### PR DESCRIPTION
Older versions of Classgraph use [reflection to get internal value of the classloader](https://github.com/classgraph/classgraph/pull/893/files). This isn't compatible with more recent versions of Quarkus, so Classgraph updated their implementation after some discussion with Quarkus team on https://github.com/quarkusio/quarkus/discussions/44283 and https://github.com/classgraph/classgraph/issues/891#issuecomment-2462249037. For compatibility with Quarkus, it would be ideal if Pact would use a version of Classgraph with the fix (4.8.178 or higher). 