### PR TITLE
Correct Java versions in developer-facing content

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
         module: [ core, 'consumer -x :consumer:junit:clojureTest', provider, pact-specification-test ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 19
+    - name: Set up JDK 18
       uses: actions/setup-java@v3
       with:
         distribution: temurin
@@ -38,7 +38,7 @@ jobs:
         jdk: [ 17, 18 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK
+      - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 Most of Pact-JVM is written in Kotlin and is built with Gradle. Tests are written using [Spock](https://spockframework.org/).
 
-Before you build, install java 11, `Gradle` and `Maven` (Maven is required to build the Maven plugin).
+Before you build, install java 17, `Gradle` and `Maven` (Maven is required to build the Maven plugin).
 
 #### To build the libraries:
 


### PR DESCRIPTION
When building recently, I had some compile problems caused by some bad content in my local maven cache. In the course of debugging that, I ended up reading the build yamls and the contributing.md. I spotted that the contributing.md suggests Java 11, which is pretty old, and not what the CI build uses. I also spotted a typo in one of the step names in the build.yaml. So I've fixed both of those, and also put in a dynamic step name on another step. 