### PR TITLE
feat(plugins): Register the standard matching rules and generators as core plugin capabilities

### DIFF
--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/CoreFieldCapabilities.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/CoreFieldCapabilities.kt
@@ -1,0 +1,274 @@
+package au.com.dius.pact.core.matchers
+
+import au.com.dius.pact.core.model.generators.Generator
+import au.com.dius.pact.core.model.generators.GeneratorTestMode
+import au.com.dius.pact.core.model.generators.PluginGenerator
+import au.com.dius.pact.core.model.generators.createGenerator
+import au.com.dius.pact.core.model.matchingrules.MatchingRule
+import au.com.dius.pact.core.model.matchingrules.PluginMatcher
+import au.com.dius.pact.core.support.Json
+import au.com.dius.pact.core.support.json.JsonValue
+import com.google.protobuf.ByteString
+import com.google.protobuf.BytesValue
+import com.google.protobuf.Struct
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.pact.plugin.v2.PluginV2
+import io.pact.plugins.jvm.core.CoreFieldGenerator
+import io.pact.plugins.jvm.core.CoreFieldMatcher
+import io.pact.plugins.jvm.core.FieldValue
+import io.pact.plugins.jvm.core.Utils.structToJson
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * The matching rules this framework can apply to a single value, and so registers a field-level
+ * handler for. Every other rule it implements is collection-wide (see [COLLECTION_RULES]).
+ */
+internal val FIELD_RULES = listOf("equality", "regex", "type", "include", "number", "integer",
+  "decimal", "boolean", "null", "date", "time", "datetime", "content-type", "not-empty", "semver",
+  "status-code")
+
+/**
+ * The matching rules that decide *which* values they apply to, and so can not be handed one value
+ * at a time - see proposal 006's non-goals. They get a handler anyway, so a plugin naming one is
+ * told why it can not have it rather than being told nothing is registered.
+ */
+internal val COLLECTION_RULES = listOf("min-type", "max-type", "min-max-type", "values",
+  "array-contains", "each-key", "each-value", "ignore-order", "min-ignore-order", "max-ignore-order",
+  "min-max-ignore-order")
+
+/**
+ * The generators this framework can apply to a single value. `ProviderState` and `MockServerURL`
+ * are included: both read host state, but it reaches them through the request's test context, which
+ * is what proposal 006 requires of any generator.
+ */
+internal val FIELD_GENERATORS = listOf("RandomInt", "RandomDecimal", "RandomHexadecimal",
+  "RandomString", "RandomBoolean", "Regex", "Uuid", "Date", "Time", "DateTime", "ProviderState",
+  "MockServerURL", "Null")
+
+/**
+ * Generators that build a value inside a structure their caller owns, so there is no single value
+ * to generate. See [COLLECTION_RULES].
+ */
+internal val COLLECTION_GENERATORS = listOf("ArrayContains")
+
+/**
+ * Applies one of this framework's standard matching rules to a single value, on behalf of a plugin
+ * that does not want to reimplement it (proposal 009). Registered against every key in
+ * [FIELD_RULES] - the rule to apply comes from the request, so one handler serves them all.
+ */
+object CoreFieldRuleMatcher : CoreFieldMatcher {
+  // A handler answers a plugin over gRPC: anything that goes wrong has to come back as the
+  // response's error field, so nothing may propagate out of here
+  @Suppress("TooGenericExceptionCaught")
+  override fun matchField(request: PluginV2.MatchFieldRequest): PluginV2.MatchFieldResponse {
+    val rule = try {
+      ruleFromRequest(request)
+    } catch (ex: Exception) {
+      logger.debug(ex) { "Could not build the matching rule for a MatchField request" }
+      return PluginV2.MatchFieldResponse.newBuilder().setError(ex.message.orEmpty()).build()
+    }
+
+    val expected = FieldValue.fromProto(request.expected)
+    val actual = FieldValue.fromProto(request.actual)
+    logger.debug { "Applying the core '${rule.name}' matching rule to the value at ${request.path}" }
+
+    val mismatches = domatch(rule, listOf(request.path), forMatching(expected), forMatching(actual),
+      BodyMismatchFactory, false, null)
+
+    return PluginV2.MatchFieldResponse.newBuilder()
+      .addAllMismatches(mismatches.map { toFieldMismatch(request, expected, actual, it.mismatch) })
+      .build()
+  }
+}
+
+/**
+ * Answers for the collection-wide rules: they are real capabilities this framework has, so they are
+ * in the catalogue, but the matching engine has to interpret them itself to know which values they
+ * cover. See [COLLECTION_RULES].
+ */
+object CollectionRuleMatcher : CoreFieldMatcher {
+  override fun matchField(request: PluginV2.MatchFieldRequest): PluginV2.MatchFieldResponse {
+    return PluginV2.MatchFieldResponse.newBuilder()
+      .setError("The '${request.key}' matching rule applies to a collection as a whole, not to a " +
+        "single value, so it can not be applied through MatchField. Match the collection with a " +
+        "content matcher instead.")
+      .build()
+  }
+}
+
+/**
+ * Applies one of this framework's standard generators to a single value, on behalf of a plugin
+ * (proposal 009). Registered against every key in [FIELD_GENERATORS].
+ */
+object CoreFieldValueGenerator : CoreFieldGenerator {
+  // See CoreFieldRuleMatcher.matchField
+  @Suppress("TooGenericExceptionCaught", "ReturnCount")
+  override fun generateField(request: PluginV2.GenerateFieldRequest): PluginV2.GenerateFieldResponse {
+    val generator = try {
+      generatorFromRequest(request)
+    } catch (ex: Exception) {
+      logger.debug(ex) { "Could not build the generator for a GenerateField request" }
+      return PluginV2.GenerateFieldResponse.newBuilder().setError(ex.message.orEmpty()).build()
+    }
+
+    val example = FieldValue.fromProto(request.exampleValue)
+    val mode = if (request.testMode == PluginV2.GenerateContentRequest.TestMode.Consumer)
+      GeneratorTestMode.Consumer else GeneratorTestMode.Provider
+
+    // A generator that does not apply on this side of the test leaves the example value alone, the
+    // same as it would when applied to a body
+    if (!generator.correspondsToMode(mode)) {
+      return PluginV2.GenerateFieldResponse.newBuilder().setValue(example.toProto()).build()
+    }
+
+    val context = structToMapOfAny(request.testContext)
+    logger.debug { "Applying the core '${generator.type}' generator to the value at ${request.path}" }
+
+    return try {
+      val generated = generator.generate(context, forMatching(example))
+      PluginV2.GenerateFieldResponse.newBuilder()
+        .setValue(toFieldValue(generated).toProto())
+        .build()
+    } catch (ex: Exception) {
+      logger.debug(ex) { "The '${generator.type}' generator failed" }
+      PluginV2.GenerateFieldResponse.newBuilder()
+        .setError("The '${generator.type}' generator could not generate a value - ${ex.message}")
+        .build()
+    }
+  }
+}
+
+/**
+ * Answers for generators that build values inside a structure their caller owns. See
+ * [CollectionRuleMatcher].
+ */
+object CollectionValueGenerator : CoreFieldGenerator {
+  override fun generateField(request: PluginV2.GenerateFieldRequest): PluginV2.GenerateFieldResponse {
+    return PluginV2.GenerateFieldResponse.newBuilder()
+      .setError("The '${request.key}' generator generates values within a collection, not a single " +
+        "value, so it can not be applied through GenerateField.")
+      .build()
+  }
+}
+
+/**
+ * The rule named by a field-level request: the rule it carries, or - if it carries none - the
+ * catalogue key it was dispatched under, so `host_match_field("not-empty", ...)` works without
+ * having to restate the rule.
+ */
+private fun ruleFromRequest(request: PluginV2.MatchFieldRequest): MatchingRule {
+  val name = request.rule.type.ifEmpty { request.key }
+  // A core handler answers for core rules only. Checking the catalogue first keeps the answer the
+  // same whatever an unrecognised name does further in - MatchingRule.create turns it into a
+  // PluginMatcher, which would send the call straight back out to a plugin.
+  require(matcherCatalogueEntries().any { it.key == name }) {
+    "'$name' is not one of the matching rules provided by this framework"
+  }
+  val values = wholeNumbersToIntegers(structToJson(request.rule.values))
+  val rule = MatchingRule.create(name, values)
+  require(rule !is PluginMatcher) {
+    "'$name' is not one of the matching rules provided by this framework"
+  }
+  return rule
+}
+
+/** The generator named by a field-level request. See [ruleFromRequest]. */
+private fun generatorFromRequest(request: PluginV2.GenerateFieldRequest): Generator {
+  val name = request.generator.type.ifEmpty { request.key }
+  // See ruleFromRequest - and createGenerator resolves a generator class by name reflectively, so
+  // an unrecognised name would otherwise surface as a ClassNotFoundException
+  require(generatorCatalogueEntries().any { it.key == name }) {
+    "'$name' is not one of the generators provided by this framework"
+  }
+  val values = wholeNumbersToIntegers(structToJson(request.generator.values))
+  val generator = createGenerator(name, values)
+  require(generator !is PluginGenerator) {
+    "'$name' is not one of the generators provided by this framework"
+  }
+  return generator
+}
+
+/**
+ * Rule and generator configuration crosses the plugin interface as a `google.protobuf.Struct`,
+ * which has one number type - a double - so a `min` of 2 arrives as `2.0`. Whole numbers are put
+ * back to integers here so a configuration value means what the plugin sent, whatever the receiving
+ * `fromJson` does with a decimal.
+ *
+ * This is the configuration-value counterpart of what [FieldValue]'s per-type arms do for the value
+ * being matched, which does not go through a `Struct` for exactly this reason.
+ */
+private fun wholeNumbersToIntegers(value: JsonValue): JsonValue = when (value) {
+  is JsonValue.Decimal -> {
+    val number = value.toBigDecimal()
+    if (number.stripTrailingZeros().scale() <= 0) {
+      JsonValue.Integer(number.toBigInteger().toString().toCharArray())
+    } else {
+      value
+    }
+  }
+  is JsonValue.Array -> JsonValue.Array(value.values.map { wholeNumbersToIntegers(it) }.toMutableList())
+  is JsonValue.Object -> JsonValue.Object(value.entries
+    .map { it.key to wholeNumbersToIntegers(it.value) }
+    .toMap()
+    .toMutableMap())
+  else -> value
+}
+
+/**
+ * The form the matching and generation code works with. Unlike [fromFieldValue], which converts a
+ * generated value back into something a document can hold, this keeps a binary value as bytes -
+ * `content-type` and `equality` both have something meaningful to say about raw bytes.
+ */
+private fun forMatching(value: FieldValue): Any? = when (value) {
+  is FieldValue.Null -> null
+  is FieldValue.Bool -> value.value
+  is FieldValue.Text -> value.value
+  is FieldValue.Integer -> value.value
+  is FieldValue.Decimal -> value.value
+  is FieldValue.Binary -> value.value
+  is FieldValue.Structured -> value.value
+}
+
+private fun toFieldMismatch(
+  request: PluginV2.MatchFieldRequest,
+  expected: FieldValue,
+  actual: FieldValue,
+  mismatch: String
+): PluginV2.ContentMismatch = PluginV2.ContentMismatch.newBuilder()
+  .setExpected(fieldValueBytes(expected))
+  .setActual(fieldValueBytes(actual))
+  .setMismatch(mismatch)
+  .setPath(request.path)
+  .setMismatchType(request.mismatchType)
+  .build()
+
+/**
+ * The bytes a mismatch reports for a value. `ContentMismatch` carries bytes so that a binary value
+ * survives being reported, which means every other value has to be rendered into some form here.
+ */
+private fun fieldValueBytes(value: FieldValue): BytesValue {
+  val bytes = when (value) {
+    is FieldValue.Null -> ByteArray(0)
+    is FieldValue.Binary -> value.value
+    is FieldValue.Text -> value.value.toByteArray()
+    is FieldValue.Structured -> value.value.serialise().toByteArray()
+    is FieldValue.Bool -> value.value.toString().toByteArray()
+    is FieldValue.Integer -> value.value.toString().toByteArray()
+    is FieldValue.Decimal -> value.value.toString().toByteArray()
+  }
+  return BytesValue.newBuilder().setValue(ByteString.copyFrom(bytes)).build()
+}
+
+/** The test context a generator reads, in the form [Generator.generate] takes it. */
+private fun structToMapOfAny(struct: Struct): MutableMap<String, Any> {
+  val json = structToJson(struct)
+  return if (json is JsonValue.Object) {
+    json.entries
+      .mapNotNull { (key, value) -> Json.fromJson(value)?.let { key to it } }
+      .toMap()
+      .toMutableMap()
+  } else {
+    mutableMapOf()
+  }
+}

--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
@@ -813,32 +813,79 @@ fun <M : Mismatch> matchSemver(
   }
 }
 
-@Suppress("MaxLineLength")
+/**
+ * Matching rule entries to add to the plugin catalogue, one per rule this framework implements.
+ *
+ * Each is keyed by the name the rule carries in a request - the same string [MatchingRule.name]
+ * returns and the plugin driver puts in `MatchFieldRequest.rule.type` - so a plugin handed a rule
+ * can name it straight back when it calls into the host, and does not have to know which
+ * specification version introduced it. That version is a value on the entry (`spec-version`)
+ * rather than part of the key. Must stay in step with `MATCHER_CATALOGUE_ENTRIES` in
+ * pact_matching, which differs only by the rules the two implement.
+ */
 fun matcherCatalogueEntries(): List<CatalogueEntry> {
-  return listOf(
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v1-equality"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v2-regex"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v2-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v2-min-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v2-max-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v2-minmax-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-number-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-integer-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-decimal-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-date"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-time"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-datetime"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-includes"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-null"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v3-content-type"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-equals-ignore-order"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-min-equals-ignore-order"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-max-equals-ignore-order"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-minmax-equals-ignore-order"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-array-contains"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-notempty"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-semver"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-each-key"),
-    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", "v4-each-value")
-  )
+  return mapOf(
+    "equality" to "V1",
+    "regex" to "V2",
+    "type" to "V2",
+    "min-type" to "V2",
+    "max-type" to "V2",
+    "min-max-type" to "V2",
+    "include" to "V3",
+    "number" to "V3",
+    "integer" to "V3",
+    "decimal" to "V3",
+    "null" to "V3",
+    "date" to "V3",
+    "time" to "V3",
+    "datetime" to "V3",
+    "content-type" to "V3",
+    "values" to "V3",
+    "array-contains" to "V4",
+    "boolean" to "V4",
+    "status-code" to "V4",
+    "not-empty" to "V4",
+    "semver" to "V4",
+    "each-key" to "V4",
+    "each-value" to "V4",
+    "ignore-order" to "V4",
+    "min-ignore-order" to "V4",
+    "max-ignore-order" to "V4",
+    "min-max-ignore-order" to "V4"
+  ).map { (key, specVersion) ->
+    CatalogueEntry(CatalogueEntryType.MATCHER, CatalogueEntryProviderType.CORE, "core", key,
+      mapOf("spec-version" to specVersion))
+  }
+}
+
+/**
+ * Generator entries to add to the plugin catalogue, one per generator this framework implements.
+ *
+ * Keyed the same way [matcherCatalogueEntries] is - by the name the generator carries in a request,
+ * which for generators is `Generator.type`, the same value the Pact file uses and the plugin driver
+ * puts in `GenerateFieldRequest.generator.type`. That is `PascalCase` for generators (`RandomInt`,
+ * `DateTime`) where it is kebab-case for matching rules; the point is that it matches what a plugin
+ * was handed, not that it looks a particular way. Must stay in step with
+ * `GENERATOR_CATALOGUE_ENTRIES` in pact_matching.
+ */
+fun generatorCatalogueEntries(): List<CatalogueEntry> {
+  return mapOf(
+    "RandomInt" to "V3",
+    "RandomDecimal" to "V3",
+    "RandomHexadecimal" to "V3",
+    "RandomString" to "V3",
+    "RandomBoolean" to "V3",
+    "Regex" to "V3",
+    "Uuid" to "V3",
+    "Date" to "V3",
+    "Time" to "V3",
+    "DateTime" to "V3",
+    "ProviderState" to "V3",
+    "MockServerURL" to "V4",
+    "ArrayContains" to "V4",
+    "Null" to "V4"
+  ).map { (key, specVersion) ->
+    CatalogueEntry(CatalogueEntryType.GENERATOR, CatalogueEntryProviderType.CORE, "core", key,
+      mapOf("spec-version" to specVersion))
+  }
 }

--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatchingConfig.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatchingConfig.kt
@@ -129,8 +129,8 @@ object MatchingConfig {
    */
   fun registerCoreCapabilities() {
     CatalogueManager.registerCoreEntries(
-      contentMatcherCatalogueEntries() + matcherCatalogueEntries() + interactionCatalogueEntries() +
-        contentHandlerCatalogueEntries()
+      contentMatcherCatalogueEntries() + matcherCatalogueEntries() + generatorCatalogueEntries() +
+        interactionCatalogueEntries() + contentHandlerCatalogueEntries()
     )
     coreContentMatchers.forEach { (key, matcher) ->
       CoreCapabilityRegistry.registerContentMatcher(key, CoreContentMatcherAdapter(matcher))
@@ -138,6 +138,13 @@ object MatchingConfig {
     coreContentGenerators.forEach { (key, generator) ->
       CoreCapabilityRegistry.registerContentGenerator(key, generator)
     }
+    // Field-level: the standard rules and generators applied to a single value, for a plugin that
+    // owns a content type but not the rules inside it (proposal 009). The collection-wide ones get
+    // a handler that says why they can not be applied one value at a time, rather than no handler.
+    FIELD_RULES.forEach { CoreCapabilityRegistry.registerFieldMatcher(it, CoreFieldRuleMatcher) }
+    COLLECTION_RULES.forEach { CoreCapabilityRegistry.registerFieldMatcher(it, CollectionRuleMatcher) }
+    FIELD_GENERATORS.forEach { CoreCapabilityRegistry.registerFieldGenerator(it, CoreFieldValueGenerator) }
+    COLLECTION_GENERATORS.forEach { CoreCapabilityRegistry.registerFieldGenerator(it, CollectionValueGenerator) }
     // The other direction: core:model reaching out to a plugin to apply a field-level rule or
     // generator. It lives here because this is the module that has both the plugin catalogue and
     // the bootstrap that runs before any matching happens (proposal 006).

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/CoreFieldCapabilitiesSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/CoreFieldCapabilitiesSpec.groovy
@@ -1,0 +1,273 @@
+package au.com.dius.pact.core.matchers
+
+import au.com.dius.pact.core.model.generators.UuidGenerator
+import au.com.dius.pact.core.model.matchingrules.TypeMatcher
+import com.google.protobuf.Struct
+import com.google.protobuf.Value
+import io.pact.plugin.v2.PluginV2
+import io.pact.plugins.jvm.core.FieldContext
+import io.pact.plugins.jvm.core.FieldTestMode
+import io.pact.plugins.jvm.core.FieldValue
+import io.pact.plugins.jvm.core.FieldKt
+import spock.lang.Specification
+
+/**
+ * The host side of proposal 009: a plugin calling back for one of this framework's standard rules
+ * or generators, applied to a single value.
+ */
+class CoreFieldCapabilitiesSpec extends Specification {
+
+  private static PluginV2.MatchFieldRequest matchRequest(
+    String key, String ruleType, Map<String, Object> ruleValues, FieldValue expected, FieldValue actual) {
+    def builder = PluginV2.MatchFieldRequest.newBuilder()
+      .setKey(key)
+      .setPath('$.one')
+      .setMismatchType('body')
+      .setExpected(expected.toProto())
+      .setActual(actual.toProto())
+    if (ruleType != null) {
+      builder.setRule(PluginV2.MatchingRule.newBuilder()
+        .setType(ruleType)
+        .setValues(toStruct(ruleValues)))
+    }
+    builder.build()
+  }
+
+  private static PluginV2.GenerateFieldRequest generateRequest(
+    String key, String generatorType, Map<String, Object> values, FieldValue example,
+    PluginV2.GenerateContentRequest.TestMode mode) {
+    def builder = PluginV2.GenerateFieldRequest.newBuilder()
+      .setKey(key)
+      .setPath('$.one')
+      .setExampleValue(example.toProto())
+      .setTestMode(mode)
+    if (generatorType != null) {
+      builder.setGenerator(PluginV2.Generator.newBuilder()
+        .setType(generatorType)
+        .setValues(toStruct(values)))
+    }
+    builder.build()
+  }
+
+  private static Struct toStruct(Map<String, Object> values) {
+    def struct = Struct.newBuilder()
+    values.each { key, value ->
+      def v = Value.newBuilder()
+      switch (value) {
+        case Number -> v.setNumberValue(((Number) value).doubleValue())
+        case Boolean -> v.setBoolValue((Boolean) value)
+        default -> v.setStringValue(value.toString())
+      }
+      struct.putFields(key, v.build())
+    }
+    struct.build()
+  }
+
+  def 'applies a core rule to a single value'() {
+    given:
+    def request = matchRequest('regex', 'regex', [regex: '\\d+'],
+      new FieldValue.Text('100'), new FieldValue.Text('200'))
+
+    when:
+    def response = CoreFieldRuleMatcher.INSTANCE.matchField(request)
+
+    then:
+    response.error == ''
+    response.mismatchesList.empty
+  }
+
+  def 'reports a mismatch against the path from the request'() {
+    given:
+    def request = matchRequest('regex', 'regex', [regex: '\\d+'],
+      new FieldValue.Text('100'), new FieldValue.Text('not a number'))
+
+    when:
+    def response = CoreFieldRuleMatcher.INSTANCE.matchField(request)
+
+    then:
+    response.error == ''
+    response.mismatchesCount == 1
+    response.getMismatches(0).path == '$.one'
+    response.getMismatches(0).mismatchType == 'body'
+    response.getMismatches(0).actual.value.toStringUtf8() == 'not a number'
+    response.getMismatches(0).mismatch.contains('to match')
+  }
+
+  /**
+   * The distinction FieldValue's per-type arms exist for: an integer actual against a decimal
+   * expected is a type mismatch, and would not be if both arrived as one JSON number type.
+   */
+  def 'keeps the numeric type of a value'() {
+    when:
+    def integer = CoreFieldRuleMatcher.INSTANCE.matchField(matchRequest('integer', 'integer', [:],
+      new FieldValue.Integer(100L), new FieldValue.Integer(200L)))
+    def decimal = CoreFieldRuleMatcher.INSTANCE.matchField(matchRequest('decimal', 'decimal', [:],
+      new FieldValue.Decimal(100.0), new FieldValue.Integer(200L)))
+
+    then:
+    integer.mismatchesList.empty
+    decimal.mismatchesCount == 1
+  }
+
+  def 'falls back to the catalogue key when the request carries no rule'() {
+    given:
+    def request = matchRequest('not-empty', null, [:], new FieldValue.Text('a'), new FieldValue.Text(''))
+
+    when:
+    def response = CoreFieldRuleMatcher.INSTANCE.matchField(request)
+
+    then:
+    response.error == ''
+    response.mismatchesCount == 1
+  }
+
+  def 'compares a binary value as bytes'() {
+    given:
+    def expected = new FieldValue.Binary([0x00, 0xfe, 0x01] as byte[])
+    def actual = new FieldValue.Binary([0x00, 0xfe, 0x02] as byte[])
+    def request = matchRequest('equality', 'equality', [:], expected, actual)
+
+    when:
+    def response = CoreFieldRuleMatcher.INSTANCE.matchField(request)
+
+    then:
+    response.mismatchesCount == 1
+    response.getMismatches(0).actual.value.toByteArray() == [0x00, 0xfe, 0x02] as byte[]
+  }
+
+  def 'a rule this framework does not provide is an error, not a call back out to a plugin'() {
+    given:
+    def request = matchRequest('type', 'creditcard', [brand: 'visa'],
+      new FieldValue.Text('4111111111111111'), new FieldValue.Text('4111111111111111'))
+
+    when:
+    def response = CoreFieldRuleMatcher.INSTANCE.matchField(request)
+
+    then:
+    response.error == "'creditcard' is not one of the matching rules provided by this framework"
+    response.mismatchesList.empty
+  }
+
+  def 'a collection-wide rule says why it can not be applied'() {
+    given:
+    def request = matchRequest('each-value', null, [:],
+      new FieldValue.Text('a'), new FieldValue.Text('b'))
+
+    when:
+    def response = CollectionRuleMatcher.INSTANCE.matchField(request)
+
+    then:
+    response.error.contains('applies to a collection as a whole')
+    response.mismatchesList.empty
+  }
+
+  def 'generates a single value'() {
+    given:
+    def request = generateRequest('RandomInt', 'RandomInt', [min: 5, max: 5],
+      new FieldValue.Integer(0L), PluginV2.GenerateContentRequest.TestMode.Consumer)
+
+    when:
+    def response = CoreFieldValueGenerator.INSTANCE.generateField(request)
+
+    then:
+    response.error == ''
+    FieldValue.fromProto(response.value) == new FieldValue.Integer(5L)
+  }
+
+  def 'a generator for the other side of the test leaves the example value alone'() {
+    given:
+    // MockServerURL only applies on the consumer side
+    def request = generateRequest('MockServerURL', 'MockServerURL',
+      [example: 'http://localhost:1234/a', regex: '.*(/a)'],
+      new FieldValue.Text('http://localhost:1234/a'), PluginV2.GenerateContentRequest.TestMode.Provider)
+
+    when:
+    def response = CoreFieldValueGenerator.INSTANCE.generateField(request)
+
+    then:
+    response.error == ''
+    FieldValue.fromProto(response.value) == new FieldValue.Text('http://localhost:1234/a')
+  }
+
+  def 'a generator this framework does not provide is an error'() {
+    given:
+    def request = generateRequest('Uuid', 'creditcard', [brand: 'visa'],
+      new FieldValue.Text('4111111111111111'), PluginV2.GenerateContentRequest.TestMode.Consumer)
+
+    when:
+    def response = CoreFieldValueGenerator.INSTANCE.generateField(request)
+
+    then:
+    response.error == "'creditcard' is not one of the generators provided by this framework"
+    !response.hasValue()
+  }
+
+  def 'a collection generator says why it can not be applied'() {
+    given:
+    def request = generateRequest('ArrayContains', null, [:], FieldValue.Null.INSTANCE,
+      PluginV2.GenerateContentRequest.TestMode.Consumer)
+
+    when:
+    def response = CollectionValueGenerator.INSTANCE.generateField(request)
+
+    then:
+    response.error.contains('generates values within a collection')
+  }
+
+  /**
+   * End to end through the driver: the catalogue entry registerCoreCapabilities registers, the
+   * resolver a plugin's callback goes through, and the handler registered under that key. A key
+   * registered on one side but not the other would only show up here.
+   */
+  def 'a plugin callback for a core rule reaches the registered handler'() {
+    given:
+    MatchingConfig.INSTANCE.registerCoreCapabilities()
+    def matcher = FieldKt.findFieldMatcher('type')
+    def context = new FieldContext('$.one', 'body', null, [:])
+
+    when:
+    def matched = matcher.matchField(TypeMatcher.INSTANCE, new FieldValue.Text('a'),
+      new FieldValue.Text('b'), context)
+    def mismatched = matcher.matchField(TypeMatcher.INSTANCE, new FieldValue.Text('a'),
+      new FieldValue.Integer(100L), context)
+
+    then:
+    matcher.core
+    matched.empty
+    mismatched.size() == 1
+    mismatched[0].path == '$.one'
+  }
+
+  /** The generator half of the callback round trip. */
+  def 'a plugin callback for a core generator reaches the registered handler'() {
+    given:
+    MatchingConfig.INSTANCE.registerCoreCapabilities()
+    def generator = FieldKt.findFieldGenerator('Uuid')
+    def context = new FieldContext('$.one', 'body', null, [:])
+
+    when:
+    def generated = generator.generateField(new UuidGenerator(), new FieldValue.Text(''),
+      FieldTestMode.CONSUMER, context)
+
+    then:
+    generator.core
+    generated instanceof FieldValue.Text
+    ((FieldValue.Text) generated).value.length() == 36
+  }
+
+  /**
+   * Every key the catalogue advertises has a handler behind it, and no handler is registered for a
+   * key that is not advertised - the two lists are what proposal 009 step 3 is.
+   */
+  def 'every registered field handler matches a catalogue entry'() {
+    given:
+    def rules = (CoreFieldCapabilitiesKt.FIELD_RULES + CoreFieldCapabilitiesKt.COLLECTION_RULES) as Set
+    def generators = (CoreFieldCapabilitiesKt.FIELD_GENERATORS + CoreFieldCapabilitiesKt.COLLECTION_GENERATORS) as Set
+    def ruleEntries = MatcherExecutorKt.matcherCatalogueEntries()*.key as Set
+    def generatorEntries = MatcherExecutorKt.generatorCatalogueEntries()*.key as Set
+
+    expect:
+    rules == ruleEntries
+    generators == generatorEntries
+  }
+}

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherCatalogueEntriesSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherCatalogueEntriesSpec.groovy
@@ -1,0 +1,129 @@
+package au.com.dius.pact.core.matchers
+
+import au.com.dius.pact.core.model.matchingrules.ArrayContainsMatcher
+import au.com.dius.pact.core.model.matchingrules.BooleanMatcher
+import au.com.dius.pact.core.model.matchingrules.ContentTypeMatcher
+import au.com.dius.pact.core.model.matchingrules.DateMatcher
+import au.com.dius.pact.core.model.matchingrules.EachKeyMatcher
+import au.com.dius.pact.core.model.matchingrules.EachValueMatcher
+import au.com.dius.pact.core.model.matchingrules.EqualsIgnoreOrderMatcher
+import au.com.dius.pact.core.model.matchingrules.EqualsMatcher
+import au.com.dius.pact.core.model.matchingrules.HttpStatus
+import au.com.dius.pact.core.model.matchingrules.IncludeMatcher
+import au.com.dius.pact.core.model.matchingrules.MaxEqualsIgnoreOrderMatcher
+import au.com.dius.pact.core.model.matchingrules.MaxTypeMatcher
+import au.com.dius.pact.core.model.matchingrules.MinEqualsIgnoreOrderMatcher
+import au.com.dius.pact.core.model.matchingrules.MinMaxEqualsIgnoreOrderMatcher
+import au.com.dius.pact.core.model.matchingrules.MinMaxTypeMatcher
+import au.com.dius.pact.core.model.matchingrules.MinTypeMatcher
+import au.com.dius.pact.core.model.matchingrules.NotEmptyMatcher
+import au.com.dius.pact.core.model.matchingrules.NullMatcher
+import au.com.dius.pact.core.model.matchingrules.NumberTypeMatcher
+import au.com.dius.pact.core.model.matchingrules.RegexMatcher
+import au.com.dius.pact.core.model.matchingrules.SemverMatcher
+import au.com.dius.pact.core.model.matchingrules.StatusCodeMatcher
+import au.com.dius.pact.core.model.matchingrules.TimeMatcher
+import au.com.dius.pact.core.model.matchingrules.TimestampMatcher
+import au.com.dius.pact.core.model.matchingrules.TypeMatcher
+import au.com.dius.pact.core.model.matchingrules.ValuesMatcher
+import au.com.dius.pact.core.model.matchingrules.expressions.MatchingRuleDefinition
+import au.com.dius.pact.core.model.generators.ArrayContainsGenerator
+import au.com.dius.pact.core.model.generators.DateGenerator
+import au.com.dius.pact.core.model.generators.DateTimeGenerator
+import au.com.dius.pact.core.model.generators.MockServerURLGenerator
+import au.com.dius.pact.core.model.generators.NullGenerator
+import au.com.dius.pact.core.model.generators.ProviderStateGenerator
+import au.com.dius.pact.core.model.generators.RandomBooleanGenerator
+import au.com.dius.pact.core.model.generators.RandomDecimalGenerator
+import au.com.dius.pact.core.model.generators.RandomHexadecimalGenerator
+import au.com.dius.pact.core.model.generators.RandomIntGenerator
+import au.com.dius.pact.core.model.generators.RandomStringGenerator
+import au.com.dius.pact.core.model.generators.RegexGenerator
+import au.com.dius.pact.core.model.generators.TimeGenerator
+import au.com.dius.pact.core.model.generators.UuidGenerator
+import spock.lang.Specification
+
+/**
+ * The catalogue entry keys are the rule and generator names, so a plugin can name one it was handed
+ * when it calls back into the host. Adding a matching rule or generator without a catalogue entry
+ * would leave it unreachable from a plugin, so this pins the lists together.
+ */
+class MatcherCatalogueEntriesSpec extends Specification {
+
+  private static final List RULES = [
+    EqualsMatcher.INSTANCE,
+    new RegexMatcher('.*'),
+    TypeMatcher.INSTANCE,
+    new MinTypeMatcher(1),
+    new MaxTypeMatcher(1),
+    new MinMaxTypeMatcher(1, 2),
+    new IncludeMatcher('a'),
+    new NumberTypeMatcher(NumberTypeMatcher.NumberType.NUMBER),
+    new NumberTypeMatcher(NumberTypeMatcher.NumberType.INTEGER),
+    new NumberTypeMatcher(NumberTypeMatcher.NumberType.DECIMAL),
+    BooleanMatcher.INSTANCE,
+    NullMatcher.INSTANCE,
+    new DateMatcher(),
+    new TimeMatcher(),
+    new TimestampMatcher(),
+    new ContentTypeMatcher('text/plain'),
+    ValuesMatcher.INSTANCE,
+    new ArrayContainsMatcher([]),
+    EqualsIgnoreOrderMatcher.INSTANCE,
+    new MinEqualsIgnoreOrderMatcher(1),
+    new MaxEqualsIgnoreOrderMatcher(1),
+    new MinMaxEqualsIgnoreOrderMatcher(1, 2),
+    new StatusCodeMatcher(HttpStatus.Success, []),
+    NotEmptyMatcher.INSTANCE,
+    SemverMatcher.INSTANCE,
+    new EachKeyMatcher(new MatchingRuleDefinition('a', TypeMatcher.INSTANCE, null, '')),
+    new EachValueMatcher(new MatchingRuleDefinition('a', TypeMatcher.INSTANCE, null, ''))
+  ]
+
+  def 'every matching rule has a catalogue entry keyed by its name'() {
+    given:
+    def entryKeys = MatcherExecutorKt.matcherCatalogueEntries()*.key as Set
+    def ruleNames = RULES*.name as Set
+
+    expect:
+    ruleNames - entryKeys == [] as Set
+    entryKeys - ruleNames == [] as Set
+  }
+
+  private static final List GENERATORS = [
+    new RandomIntGenerator(0, 10),
+    new RandomDecimalGenerator(4),
+    new RandomHexadecimalGenerator(4),
+    new RandomStringGenerator(4),
+    RandomBooleanGenerator.INSTANCE,
+    new RegexGenerator('.*'),
+    new UuidGenerator(),
+    new DateGenerator(),
+    new TimeGenerator(),
+    new DateTimeGenerator(),
+    new ProviderStateGenerator('a'),
+    new MockServerURLGenerator('http://localhost:8080', '.*'),
+    new ArrayContainsGenerator([]),
+    NullGenerator.INSTANCE
+  ]
+
+  def 'every generator has a catalogue entry keyed by its name'() {
+    given:
+    def entryKeys = MatcherExecutorKt.generatorCatalogueEntries()*.key as Set
+    def generatorNames = GENERATORS*.type as Set
+
+    expect:
+    generatorNames - entryKeys == [] as Set
+    entryKeys - generatorNames == [] as Set
+  }
+
+  def 'every catalogue entry records the specification version it was introduced in'() {
+    given:
+    def entries = MatcherExecutorKt.matcherCatalogueEntries() + MatcherExecutorKt.generatorCatalogueEntries()
+
+    expect:
+    entries.every {
+      it.values['spec-version'] in ['V1', 'V2', 'V3', 'V4']
+    }
+  }
+}


### PR DESCRIPTION
Proposal 009: let a plugin delegate a standard Pact rule to the framework it is running under, instead of reimplementing it. The mechanism has been in the plugin driver since 006; nothing registered anything behind it, so a plugin naming a standard rule resolved the catalogue entry and then failed with "No core field matcher registered for 'type'".

Catalogue entries:

- the matcher entries are re-keyed by the name the rule carries in a request (`MatchingRule.name`, the same string the driver puts in `MatchFieldRequest.rule.type`) rather than the specification version prefixed to the name, which moves to a `spec-version` value on the entry. That also settles two spellings that had drifted from the Rust implementation (`v4-notempty`, `v2-minmax-type`);
- generator entries are added - there were none at all, so `findFieldGenerator("Uuid")` failed at the catalogue step and no `generator/*` capability was ever advertised;
- both lists are now exactly the rules and generators this framework implements, pinned by a test that compares them against every rule and generator class.

Handlers, in the new `CoreFieldCapabilities.kt`:

- `CoreFieldRuleMatcher` answers for the 16 rules that act on a single value, and `CoreFieldValueGenerator` for the 13 generators that are a pure function of their configuration and the test context;
- the collection-wide rules (`min-type`, `values`, `array-contains`, `each-key`/`each-value`, the `*ignore-order` family) and the `ArrayContains` generator are registered too, but answer with why they can not be applied one value at a time - they stay framework-only per 006's non-goals, and a plugin naming one should be told that rather than that nothing is registered;
- a rule or generator name this framework does not provide is an error, not a call back out: an unrecognised name parses into the plugin carrier (or, for a generator, fails reflective class lookup), so the name is checked against the catalogue first.

Rule and generator configuration crosses the plugin interface as a `google.protobuf.Struct`, which has one number type, so a plugin's `min: 2` arrives as `2.0`; whole floats are put back to integers on the way in so a configuration value means what the plugin sent.