### PR TITLE
fix: Allow Gradle pact file verification without a broker

### DIFF
--- a/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
+++ b/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
@@ -127,25 +127,27 @@ class PactPlugin extends PactPluginBase {
   @SuppressWarnings('CatchRuntimeException')
   @CompileStatic
   private void setupPactConsumersFromBroker(GradleProviderInfo provider, Project project, PactPluginExtension ext) {
-    if (ext.broker && project.gradle.startParameter.taskNames.any {
+    Broker broker = ext.broker
+    if (broker == null || !project.gradle.startParameter.taskNames.any {
       it.toLowerCase().contains(PACT_VERIFY.toLowerCase()) }) {
-      Map<String, Object> options = [:]
-      if (ext.broker.pactBrokerUsername) {
-        options.authentication = ['basic', ext.broker.pactBrokerUsername, ext.broker.pactBrokerPassword]
-      } else if (ext.broker.pactBrokerToken) {
-        options.authentication = ['bearer', ext.broker.pactBrokerToken, ext.broker.pactBrokerAuthenticationHeader]
-      }
-      if (provider.brokerConfig.enablePending) {
-        options.enablePending = true
-        options.providerTags = provider.brokerConfig.providerTags
-      }
-      try {
-        provider.consumers = provider.hasPactsFromPactBrokerWithSelectorsV2(options, ext.broker.pactBrokerUrl,
-          provider.brokerConfig.selectors)
-      } catch (RuntimeException ex) {
-        throw new GradleScriptException("Failed to fetch pacts from pact broker ${ext.broker.pactBrokerUrl}",
-          ex)
-      }
+      return
+    }
+
+    Map<String, Object> options = [:]
+    if (broker.pactBrokerUsername) {
+      options.authentication = ['basic', broker.pactBrokerUsername, broker.pactBrokerPassword]
+    } else if (broker.pactBrokerToken) {
+      options.authentication = ['bearer', broker.pactBrokerToken, broker.pactBrokerAuthenticationHeader]
+    }
+    if (provider.brokerConfig.enablePending) {
+      options.enablePending = true
+      options.providerTags = provider.brokerConfig.providerTags
+    }
+    try {
+      provider.consumers = provider.hasPactsFromPactBrokerWithSelectorsV2(options, broker.pactBrokerUrl,
+        provider.brokerConfig.selectors)
+    } catch (RuntimeException ex) {
+      throw new GradleScriptException("Failed to fetch pacts from pact broker ${broker.pactBrokerUrl}", ex)
     }
   }
 }

--- a/provider/gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPluginSpec.groovy
+++ b/provider/gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPluginSpec.groovy
@@ -230,6 +230,29 @@ class PactPluginSpec extends Specification {
     !consumer.stateChangeUsesBody
   }
 
+  def 'hasPactWith - configures a local pact file without a broker when pactVerify is requested'() {
+    given:
+    def pactFile = project.file('path/to/pact')
+    project.gradle.startParameter.setTaskNames(['pactVerify'])
+    project.pact {
+      serviceProviders {
+        ProviderA {
+          hasPactWith('ConsumerA') {
+            pactSource = pactFile
+          }
+        }
+      }
+    }
+
+    when:
+    project.evaluate()
+    def consumer = project.tasks.pactVerify_ProviderA.providerToVerify.consumers.first()
+
+    then:
+    consumer.name == 'ConsumerA'
+    consumer.pactSource == pactFile
+  }
+
   def 'hasPactWith - configures a group from a directory'() {
     given:
     def resource = getClass().classLoader.getResource('pacts/foo_pact.json')


### PR DESCRIPTION
The Gradle provider plugin throws a null-pointer error while configuring `pactVerify` when a consumer supplies a local pact file through `hasPactWith` and the top-level broker block is absent. File-backed verification is a supported path and must not require broker credentials or a broker URL. The failure is rooted in the plugin's broker-consumer setup path dereferencing the nullable `PactPluginExtension.broker` configuration while a verification task is requested. The issue is open and unassigned, and the bundled timeline contains no competing or closed prior pull requests.

## Summary

Update `PactPlugin.setupPactConsumersFromBroker` to capture the optional broker configuration once and return without inspecting broker fields when it is absent or when no Pact verification task was requested. Use that non-null local value for authentication, URL, and error-message access so the broker-only path cannot re-read a nullable extension property; retain the existing broker-backed behavior unchanged. Add a regression to `PactPluginSpec` that sets the Gradle start parameters to request `pactVerify`, configures a provider with `hasPactWith` and a local file source but no broker block, evaluates the project, and confirms the provider verification task retains the configured file consumer without attempting broker setup.

## Test plan

- Request `pactVerify` with a provider whose consumer uses a local pact file and no broker block; project evaluation succeeds and the generated provider task contains that file-backed consumer.
- Configure no broker while other/non-verification task names are present; plugin evaluation continues to skip broker consumer loading.
- Preserve existing broker-backed verification behavior: when a broker is configured and a Pact verification task is requested, authentication/selectors and the broker URL continue to feed the existing consumer-loading path.

Fixes #1587
